### PR TITLE
Fix links to competitors in the docs

### DIFF
--- a/docs/src/content/docs/about/comparison.mdx
+++ b/docs/src/content/docs/about/comparison.mdx
@@ -13,10 +13,10 @@ advantage of being able to provide features that are powerful but complex.
 There are other `ls(1)` alternatives that have been around for longer and have
 sizeable user bases.
 
-| Tool                                                     | Language | GitHub stars                                  |
-| -------------------------------------------------------- | -------- | --------------------------------------------- |
+| Tool                                                 | Language | GitHub stars                                  |
+| ---------------------------------------------------- | -------- | --------------------------------------------- |
 | [exa](https://github.com/ogham/exa)                  | Rust     | <Stars owner="ogham" repo="exa" />            |
-| [eza](https://github.com/eza-community/eza)      | Rust     | <Stars owner="eza-community" repo="eza" />    |
+| [eza](https://github.com/eza-community/eza)          | Rust     | <Stars owner="eza-community" repo="eza" />    |
 | [`lsd`](https://github.com/lsd-rs/lsd)               | Rust     | <Stars owner="lsd-rs" repo="lsd" />           |
 | [`colorls`](https://github.com/athityakumar/colorls) | Ruby     | <Stars owner="athityakumar" repo="colorls" /> |
 

--- a/docs/src/content/docs/about/comparison.mdx
+++ b/docs/src/content/docs/about/comparison.mdx
@@ -15,10 +15,10 @@ sizeable user bases.
 
 | Tool                                                     | Language | GitHub stars                                  |
 | -------------------------------------------------------- | -------- | --------------------------------------------- |
-| [exa](<(https://github.com/ogham/exa)>)                  | Rust     | <Stars owner="ogham" repo="exa" />            |
-| [eza](<(https://github.com/eza-community/eza/eza)>)      | Rust     | <Stars owner="eza-community" repo="eza" />    |
-| [`lsd`](<(https://github.com/lsd-rs/lsd)>)               | Rust     | <Stars owner="lsd-rs" repo="lsd" />           |
-| [`colorls`](<(https://github.com/athityakumar/colorls)>) | Ruby     | <Stars owner="athityakumar" repo="colorls" /> |
+| [exa](https://github.com/ogham/exa)                  | Rust     | <Stars owner="ogham" repo="exa" />            |
+| [eza](https://github.com/eza-community/eza)      | Rust     | <Stars owner="eza-community" repo="eza" />    |
+| [`lsd`](https://github.com/lsd-rs/lsd)               | Rust     | <Stars owner="lsd-rs" repo="lsd" />           |
+| [`colorls`](https://github.com/athityakumar/colorls) | Ruby     | <Stars owner="athityakumar" repo="colorls" /> |
 
 <Pls /> strives to provide all the features expected from these tools, and more.
 For an idea, here is a comparison between <Pls /> and the most popular


### PR DESCRIPTION
Links to other projects in the comparison table are currently not working due to a syntax problem 

<img width="492" alt="image" src="https://github.com/user-attachments/assets/50229d6a-cc3d-4d2f-8d6a-db90dca0deca">
<img width="889" alt="image" src="https://github.com/user-attachments/assets/6ab52284-099b-44ca-bb44-7137c52bdff3">
