### PR TITLE
Return `Window` even when pixel measurements not reported in ioctl

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,11 @@ use log::debug;
 use std::sync::LazyLock;
 
 static PLS: LazyLock<Pls> = LazyLock::new(|| {
-	let supports_gfx = is_supported();
 	let window = Window::try_new();
+	let supports_gfx = match &window {
+		Some(win) if win.ws_xpixel > 0 && win.ws_ypixel > 0 => is_supported(),
+		_ => false,
+	};
 
 	Pls {
 		supports_gfx,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,8 @@ use log::debug;
 use std::sync::LazyLock;
 
 static PLS: LazyLock<Pls> = LazyLock::new(|| {
-	let (supports_gfx, window) = match (is_supported(), Window::try_new()) {
-		(true, Some(window)) => (true, Some(window)),
-		_ => (false, None),
-	};
+	let supports_gfx = is_supported();
+	let window = Window::try_new();
 
 	Pls {
 		supports_gfx,

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -19,7 +19,7 @@ impl Window {
 		let mut win = Self::default();
 		#[allow(clippy::useless_conversion)]
 		let r = unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ.into(), &mut win) };
-		if r == 0 && win.ws_xpixel > win.ws_col && win.ws_ypixel > win.ws_row {
+		if r == 0 && win.ws_row > 0 && win.ws_col > 0 {
 			return Some(win);
 		}
 		warn!("Could not determine cell dimensions.");


### PR DESCRIPTION
Hey! 👋 

I was trying out `pls`, but unfortunately the `grid` option does not work on my setup, which is using tmux and alacritty.

Above is the current change, and below is the newest release version of `pls`.
<img width="1525" alt="Screenshot 2024-10-02 at 22 40 56" src="https://github.com/user-attachments/assets/247f8a20-8cf5-40a2-b7f6-6725f481c7fe">

---

Seems like without the window we cannot calculate the grid columns properly, but set the column amount as one, which results the grid option not working in terminal emulators like Alacritty that do not support Kittys's terminal graphics protocol.

This commit removes the pattern match and returns the supports_gfx boolean and window separately. Now when the window is returned the grid is properly rendered.

Tested on Alacritty version `0.13.2`.