### PR TITLE
Build macOS universal binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,11 @@ jobs:
           - build: linux
             os: ubuntu-latest
             target: x86_64-unknown-linux-musl
+            suffix: x86_64-unknown-linux-musl
           - build: macos
             os: macos-latest
-            target: x86_64-apple-darwin
+            target: x86_64-apple-darwin,aarch64-apple-darwin
+            suffix: universal-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -80,35 +82,21 @@ jobs:
           rust_cache_key: cross
           rust_target: ${{ matrix.target }}
 
-      - name: Build release (Linux)
-        if: matrix.build == 'linux'
+      - name: Build release
         run: |
           just get-cross
           just cross ${{ matrix.target }}
 
-      - name: Build release (macOS universal)
+      - name: Lipo binaries (macOS only)
         if: matrix.build == 'macos'
         run: |
-          rustup target add aarch64-apple-darwin
-          cargo build --release --target x86_64-apple-darwin
-          cargo build --release --target aarch64-apple-darwin
-          lipo -create -output target/pls \
-            target/x86_64-apple-darwin/release/pls \
-            target/aarch64-apple-darwin/release/pls
+          just lipo ${{ matrix.suffix }} ${{ matrix.target }}
 
-      - name: Upload binary artifact (Linux)
-        if: matrix.build == 'linux'
+      - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:
-          name: pls-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/pls
-
-      - name: Upload binary artifact (macOS)
-        if: matrix.build == 'macos'
-        uses: actions/upload-artifact@v7
-        with:
-          name: pls-universal-apple-darwin
-          path: target/pls
+          name: pls-${{ matrix.suffix }}
+          path: target/${{ matrix.suffix }}/release/pls
 
   docs:
     name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,16 +80,35 @@ jobs:
           rust_cache_key: cross
           rust_target: ${{ matrix.target }}
 
-      - name: Build release
+      - name: Build release (Linux)
+        if: matrix.build == 'linux'
         run: |
           just get-cross
           just cross ${{ matrix.target }}
 
-      - name: Upload binary artifact
+      - name: Build release (macOS universal)
+        if: matrix.build == 'macos'
+        run: |
+          rustup target add aarch64-apple-darwin
+          cargo build --release --target x86_64-apple-darwin
+          cargo build --release --target aarch64-apple-darwin
+          lipo -create -output target/pls \
+            target/x86_64-apple-darwin/release/pls \
+            target/aarch64-apple-darwin/release/pls
+
+      - name: Upload binary artifact (Linux)
+        if: matrix.build == 'linux'
         uses: actions/upload-artifact@v7
         with:
           name: pls-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/pls
+
+      - name: Upload binary artifact (macOS)
+        if: matrix.build == 'macos'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pls-universal-apple-darwin
+          path: target/pls
 
   docs:
     name: Build docs

--- a/justfile
+++ b/justfile
@@ -62,9 +62,27 @@ release:
 get-cross:
     [ -x "$(command -v cross)" ] || cargo install cross
 
-# Build a release binary for the given target with `cross`.
-cross target:
-    cross build --release --verbose --target {{ target }}
+# Build a release binary for the given targets with `cross`.
+cross targets:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IFS=',' read -ra items <<< "{{ targets }}"
+    for target in "${items[@]}"; do
+        cross build --release --verbose --target "$target"
+    done
+
+# Combine the given binaries into a universal binary.
+lipo output inputs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IFS=',' read -ra items <<< "{{ inputs }}"
+    paths=()
+    for target in "${items[@]}"; do
+        paths+=("target/$target/release/pls")
+    done
+    out_path="target/{{ output }}/release/pls"
+    mkdir -p "$(dirname "$out_path")"
+    lipo -create -output "$out_path" "${paths[@]}"
 
 ###########
 # Aliases #


### PR DESCRIPTION
- Split build step into conditional Linux/macOS paths
- macOS now builds both x86_64-apple-darwin and aarch64-apple-darwin targets
- Combine architectures with lipo to create universal binary
- Update artifact name from pls-x86_64-apple-darwin to pls-universal-apple-darwin
- Linux build unchanged (still uses cross)