### PR TITLE
Build arm64 binary for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
             os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             suffix: x86_64-unknown-linux-musl
+          - build: linux
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            suffix: aarch64-unknown-linux-musl
           - build: macos
             os: macos-latest
             target: x86_64-apple-darwin,aarch64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build:
-          - linux
-          - macos
         include:
           - build: linux
             os: ubuntu-latest
@@ -86,8 +83,11 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           install_tools: just,cross
-          rust_cache_key: cross
+          rust_cache_key: cross-${{ matrix.suffix }}
           rust_target: ${{ matrix.target }}
+
+      - name: Purge cross cache
+        run: cargo clean
 
       - name: Build release
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,15 @@ jobs:
           just lint
 
   unit:
-    name: Run unit test
+    name: Run unit test (${{ matrix.name }})
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        include:
+          - name: Linux
+            os: ubuntu-latest
+          - name: macOS
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,6 @@ jobs:
           rust_cache_key: cross-${{ matrix.suffix }}
           rust_target: ${{ matrix.target }}
 
-      - name: Purge cross cache
-        run: cargo clean
-
       - name: Build release
         run: |
           just cross ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: just test
 
   build:
-    name: Build release
+    name: Build release (${{ matrix.name }})
     needs:
       - lint
       - unit
@@ -62,15 +62,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - build: linux
+          - name: Linux x86_64
+            build: linux
             os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             suffix: x86_64-unknown-linux-musl
-          - build: linux
+          - name: Linux ARM64
+            build: linux
             os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             suffix: aarch64-unknown-linux-musl
-          - build: macos
+          - name: macOS universal
+            build: macos
             os: macos-latest
             target: x86_64-apple-darwin,aarch64-apple-darwin
             suffix: universal-apple-darwin

--- a/.gitignore
+++ b/.gitignore
@@ -19,62 +19,8 @@ pre-commit.pyz
 # AI
 .claude
 
-# General macOS artifacts
+# macOS
 .DS_Store
-.localized
-__MACOSX/
 .AppleDouble
 .LSOverride
-Icon[
-]
-
-# Resource forks
 ._*
-
-# Files and directories that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-.com.apple.timemachine.donotpresent
-.com.apple.timemachine.supported
-.PKInstallSandboxManager
-.PKInstallSandboxManager-SystemSoftware
-.hotfiles.btree
-.vol
-.file
-.disk_label*
-lost+found
-.HFS+ Private Directory Data[
-]
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
-
-# Mac OS 6 to 9
-Desktop DB
-Desktop DF
-TheFindByContentFolder
-TheVolumeSettingsFolder
-.FBCIndex
-.FBCSemaphoreFile
-.FBCLockFolder
-
-# Quota system
-.quota.group
-.quota.user
-.quota.ops.group
-.quota.ops.user
-
-# TimeMachine
-Backups.backupdb
-.MobileBackups
-.MobileBackups.trash
-MobileBackups.trash
-tmbootpicker.efi

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,63 @@ pre-commit.pyz
 
 # AI
 .claude
+
+# General macOS artifacts
+.DS_Store
+.localized
+__MACOSX/
+.AppleDouble
+.LSOverride
+Icon[
+]
+
+# Resource forks
+._*
+
+# Files and directories that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.com.apple.timemachine.supported
+.PKInstallSandboxManager
+.PKInstallSandboxManager-SystemSoftware
+.hotfiles.btree
+.vol
+.file
+.disk_label*
+lost+found
+.HFS+ Private Directory Data[
+]
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Mac OS 6 to 9
+Desktop DB
+Desktop DF
+TheFindByContentFolder
+TheVolumeSettingsFolder
+.FBCIndex
+.FBCSemaphoreFile
+.FBCLockFolder
+
+# Quota system
+.quota.group
+.quota.user
+.quota.ops.group
+.quota.ops.user
+
+# TimeMachine
+Backups.backupdb
+.MobileBackups
+.MobileBackups.trash
+MobileBackups.trash
+tmbootpicker.efi

--- a/docs/src/content/docs/guides/get_started.mdx
+++ b/docs/src/content/docs/guides/get_started.mdx
@@ -137,8 +137,8 @@ eget --pre-release pls-rs/pls
 
 2. Download the binary as per your operating system.
    - `pls-universal-apple-darwin` for macOS
-   - `pls-x86_64-unknown-linux-musl` for Linux (Intel/AMD)
-   - `pls-aarch64-unknown-linux-musl` for Linux (ARM64)
+   - `pls-x86_64-unknown-linux-musl` for Linux (x86_64 e.g. Intel, AMD)
+   - `pls-aarch64-unknown-linux-musl` for Linux (arm64)
 
 3. Unzip the archive and find the single `pls` executable.
 

--- a/docs/src/content/docs/guides/get_started.mdx
+++ b/docs/src/content/docs/guides/get_started.mdx
@@ -136,8 +136,9 @@ eget --pre-release pls-rs/pls
      3. Scroll down to the "Artifacts" section.
 
 2. Download the binary as per your operating system.
-   - `pls-x86_64-apple-darwin` for macOS
-   - `pls-x86_64-unknown-linux-musl` for Linux
+   - `pls-universal-apple-darwin` for macOS
+   - `pls-x86_64-unknown-linux-musl` for Linux (Intel/AMD)
+   - `pls-aarch64-unknown-linux-musl` for Linux (ARM64)
 
 3. Unzip the archive and find the single `pls` executable.
 

--- a/pkg/brew/pls.template
+++ b/pkg/brew/pls.template
@@ -10,8 +10,13 @@ class Pls < Formula
     url "{{ MAC_URL }}"
     sha256 "{{ MAC_SHA }}"
   elsif OS.linux?
-    url "{{ LINUX_URL }}"
-    sha256 "{{ LINUX_SHA }}"
+    if Hardware::CPU.arm?
+      url "{{ LINUX_ARM_URL }}"
+      sha256 "{{ LINUX_ARM_SHA }}"
+    else
+      url "{{ LINUX_X86_URL }}"
+      sha256 "{{ LINUX_X86_SHA }}"
+    end
   end
 
   depends_on "libgit2"

--- a/pkg/brew/update_formula.sh
+++ b/pkg/brew/update_formula.sh
@@ -13,17 +13,26 @@ curl -sL "$MAC_URL" -o /tmp/mac_asset
 MAC_SHA=$(shasum -a 256 /tmp/mac_asset | awk '{ print $1 }')
 echo "SHA256 for macOS asset is $MAC_SHA."
 
-LINUX_URL=$(echo "$RELEASE" | jq -r '.assets[] | select(.name | contains("unknown-linux-musl")).browser_download_url')
-echo "Downloading Linux asset from $LINUX_URL."
+LINUX_X86_URL=$(echo "$RELEASE" | jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-musl")).browser_download_url')
+echo "Downloading Linux x86_64 asset from $LINUX_X86_URL."
 
-curl -sL "$LINUX_URL" -o /tmp/linux_asset
-LINUX_SHA=$(shasum -a 256 /tmp/linux_asset | awk '{ print $1 }')
-echo "SHA256 for Linux asset is $LINUX_SHA."
+curl -sL "$LINUX_X86_URL" -o /tmp/linux_x86_asset
+LINUX_X86_SHA=$(shasum -a 256 /tmp/linux_x86_asset | awk '{ print $1 }')
+echo "SHA256 for Linux x86_64 asset is $LINUX_X86_SHA."
+
+LINUX_ARM_URL=$(echo "$RELEASE" | jq -r '.assets[] | select(.name | contains("aarch64-unknown-linux-musl")).browser_download_url')
+echo "Downloading Linux aarch64 asset from $LINUX_ARM_URL."
+
+curl -sL "$LINUX_ARM_URL" -o /tmp/linux_arm_asset
+LINUX_ARM_SHA=$(shasum -a 256 /tmp/linux_arm_asset | awk '{ print $1 }')
+echo "SHA256 for Linux aarch64 asset is $LINUX_ARM_SHA."
 
 sed -e "s|{{ VERSION }}|$VERSION|g" \
     -e "s|{{ MAC_URL }}|$MAC_URL|g" \
     -e "s|{{ MAC_SHA }}|$MAC_SHA|g" \
-    -e "s|{{ LINUX_URL }}|$LINUX_URL|g" \
-    -e "s|{{ LINUX_SHA }}|$LINUX_SHA|g" "$1" > "$2"
+    -e "s|{{ LINUX_X86_URL }}|$LINUX_X86_URL|g" \
+    -e "s|{{ LINUX_X86_SHA }}|$LINUX_X86_SHA|g" \
+    -e "s|{{ LINUX_ARM_URL }}|$LINUX_ARM_URL|g" \
+    -e "s|{{ LINUX_ARM_SHA }}|$LINUX_ARM_SHA|g" "$1" > "$2"
 
 echo "Formula written!"


### PR DESCRIPTION
### Changes

**CI (`.github/workflows/ci.yml`)**
- Added `aarch64-unknown-linux-musl` to the build matrix
- Scoped the Rust cache key per target (`cross-${{ matrix.suffix }}`) to prevent cross-arch cache collisions
- Added `cargo clean` step before build to purge stale artifacts between matrix runs

**Homebrew formula (`pkg/brew/`)**
- `pls.template`: Split Linux into architecture if/else branch
- `update_formula.sh`: Fetches both Linux assets, substitutes hashes & URLs

**Docs (`get_started.mdx`)**
- Updated artifact names: macOS → `universal-apple-darwin`
- Linux now lists both x86_64 and ARM64 variants

**`.gitignore`**
- Added  macOS artifact patterns (e.g., `.DS_Store`, etc)