### PR TITLE
Implement performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +278,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "env_filter"
@@ -752,6 +783,7 @@ dependencies = [
  "log",
  "number_prefix",
  "path-clean",
+ "rayon",
  "regex",
  "resvg",
  "serde",
@@ -814,6 +846,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,7 @@ dependencies = [
  "figment",
  "git2",
  "home",
+ "indexmap",
  "libc",
  "log",
  "number_prefix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ libc = "0.2.180"
 log = { version = "0.4.29", features = ["release_max_level_off"] }
 number_prefix = "0.4.0"
 path-clean = "1.0.1"
+rayon = "1.11.0"
 regex = { version = "1.12.3", default-features = false, features = ["std", "perf"] }
 resvg = { version = "0.46.0", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ env_logger = { version = "0.11.8", default-features = false }
 figment = { version = "0.10.19", features = ["yaml", "test"] }
 git2 = { version = "0.20.4", default-features = false }
 home = "0.5.12"
+indexmap = "2.13.0"
 libc = "0.2.180"
 log = { version = "0.4.29", features = ["release_max_level_off"] }
 number_prefix = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,12 @@ panic = "abort"
 lto = true
 strip = true
 
+# Release-like profile that keeps symbols/debuginfo for profiling with samply.
+[profile.profiling]
+inherits = "release"
+strip = false
+debug = true
+
 [package.metadata.release]
 sign-commit = true
 sign-tag = true

--- a/src/args/dir_group.rs
+++ b/src/args/dir_group.rs
@@ -6,7 +6,6 @@ use crate::traits::Imp;
 use crate::PLS;
 use log::debug;
 use rayon::prelude::*;
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fs::DirEntry;
 use std::os::unix::ffi::OsStrExt;
@@ -240,16 +239,7 @@ impl DirGroup {
 		let mut child_map: HashMap<String, Vec<Node>> = HashMap::new();
 		nodes.into_iter().for_each(|mut node| {
 			if let Some(collapse) = node.collapse_name.take() {
-				match child_map.entry(collapse) {
-					Entry::Occupied(mut entry) => {
-						let children = entry.get_mut();
-						children.push(node);
-					}
-					Entry::Vacant(entry) => {
-						let children = vec![node];
-						entry.insert(children);
-					}
-				};
+				child_map.entry(collapse).or_default().push(node);
 			} else {
 				roots.push(node);
 			}

--- a/src/args/dir_group.rs
+++ b/src/args/dir_group.rs
@@ -1,5 +1,4 @@
 use crate::args::input::Input;
-use crate::enums::DetailField;
 use crate::exc::Exc;
 use crate::models::{Node, OwnerMan};
 use crate::traits::Imp;
@@ -41,10 +40,7 @@ impl DirGroup {
 	///
 	/// Since nodes can be nested, the function uses the flattened output of
 	/// each node's [`Node::entries`].
-	pub fn entries(
-		&self,
-		owner_man: &mut OwnerMan,
-	) -> Result<Vec<HashMap<DetailField, String>>, Exc> {
+	pub fn entries(&self, owner_man: &mut OwnerMan) -> Result<Vec<Vec<String>>, Exc> {
 		let mut nodes = self.nodes()?;
 		if PLS.args.collapse {
 			nodes = Self::make_tree(nodes);

--- a/src/args/dir_group.rs
+++ b/src/args/dir_group.rs
@@ -1,6 +1,7 @@
 use crate::args::input::Input;
+use crate::enums::{DetailField, SortField};
 use crate::exc::Exc;
-use crate::models::{Node, OwnerMan};
+use crate::models::{Node, OwnerMan, Owners};
 use crate::traits::Imp;
 use crate::PLS;
 use log::debug;
@@ -45,13 +46,22 @@ impl DirGroup {
 		if PLS.args.collapse {
 			nodes = Self::make_tree(nodes);
 		}
-		Self::re_sort(&mut nodes, owner_man);
+
+		// Owners are looked up through an immutable, shareable view rather than
+		// the mutable manager. When any owner column or owner-based sort is in
+		// play, resolve every owner up front and then hand out that view.
+		if owners_needed() {
+			Self::resolve_owners(&nodes, owner_man);
+		}
+		let owners = owner_man.owners();
+
+		Self::re_sort(&mut nodes, owners);
 
 		let entries = nodes
 			.iter()
 			.flat_map(|node| {
 				node.entries(
-					owner_man,
+					owners,
 					&self.input.conf,
 					&self.input.conf.app_const,
 					&self.input.conf.entry_const,
@@ -142,15 +152,30 @@ impl DirGroup {
 	/// This function iterates over all the sort bases and sorts the given list
 	/// of nodes. It is invoked both from the top-level and from each parent
 	/// node to sort its children.
-	fn re_sort(nodes: &mut [Node], owner_man: &mut OwnerMan) {
+	fn re_sort(nodes: &mut [Node], owners: Owners) {
 		if nodes.len() <= 1 {
 			return;
 		}
 		PLS.args.sort_bases.iter().rev().for_each(|field| {
-			nodes.sort_by(|a, b| field.compare(a, b, owner_man));
+			nodes.sort_by(|a, b| field.compare(a, b, owners));
 		});
 		for node in nodes {
-			Self::re_sort(&mut node.children, owner_man);
+			Self::re_sort(&mut node.children, owners);
+		}
+	}
+
+	/// Resolve the owning user and group of every node in the given forest.
+	///
+	/// This populates the [`OwnerMan`] cache up front so that rendering can look
+	/// owners up through an immutable [`Owners`] view without touching the cache.
+	fn resolve_owners(nodes: &[Node], owner_man: &mut OwnerMan) {
+		for node in nodes {
+			if let Some(meta) = node.meta_ok() {
+				use std::os::unix::fs::MetadataExt;
+				owner_man.user(meta.uid());
+				owner_man.group(meta.gid());
+			}
+			Self::resolve_owners(&node.children, owner_man);
 		}
 	}
 
@@ -219,4 +244,25 @@ impl DirGroup {
 		roots.extend(child_map.into_values().flatten());
 		roots
 	}
+}
+
+/// Whether the current invocation needs owner information resolved.
+///
+/// Owner resolution is only worth its (serial) cost when an owner column is
+/// displayed or the nodes are sorted by owner; other views never consult the
+/// owner cache.
+pub(crate) fn owners_needed() -> bool {
+	use DetailField::{Gid, Group, Uid, User};
+	use SortField::{
+		Group as GroupSort, Group_ as GroupSortRev, User as UserSort, User_ as UserSortRev,
+	};
+	PLS.args
+		.details
+		.iter()
+		.any(|field| matches!(field, User | Uid | Group | Gid))
+		|| PLS
+			.args
+			.sort_bases
+			.iter()
+			.any(|field| matches!(field, UserSort | UserSortRev | GroupSort | GroupSortRev))
 }

--- a/src/args/dir_group.rs
+++ b/src/args/dir_group.rs
@@ -195,8 +195,8 @@ impl DirGroup {
 
 		let mut roots = vec![];
 		let mut child_map: HashMap<String, Vec<Node>> = HashMap::new();
-		nodes.into_iter().for_each(|node| {
-			if let Some(collapse) = node.collapse_name.clone() {
+		nodes.into_iter().for_each(|mut node| {
+			if let Some(collapse) = node.collapse_name.take() {
 				match child_map.entry(collapse) {
 					Entry::Occupied(mut entry) => {
 						let children = entry.get_mut();

--- a/src/args/dir_group.rs
+++ b/src/args/dir_group.rs
@@ -108,7 +108,7 @@ impl DirGroup {
 			return None;
 		}
 
-		let mut node = Node::new(&entry.path());
+		let mut node = Node::from_entry(&entry);
 
 		debug!("Checking visibility of typ {:?}.", node.typ);
 		if !PLS.args.typs.contains(&node.typ) {

--- a/src/args/dir_group.rs
+++ b/src/args/dir_group.rs
@@ -5,6 +5,7 @@ use crate::models::{Node, OwnerMan, Owners};
 use crate::traits::Imp;
 use crate::PLS;
 use log::debug;
+use rayon::prelude::*;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fs::DirEntry;
@@ -47,19 +48,26 @@ impl DirGroup {
 			nodes = Self::make_tree(nodes);
 		}
 
-		// Owners are looked up through an immutable, shareable view rather than
-		// the mutable manager. When any owner column or owner-based sort is in
-		// play, resolve every owner up front and then hand out that view.
+		// Owners are the only per-node datum that cannot be resolved on a
+		// rendering thread (the user/group cache is `!Sync`). When any owner
+		// column or owner-based sort is in play, resolve every owner up front —
+		// after prefetching metadata in parallel so the resolution itself does
+		// not stat serially — and then hand out an immutable, shareable view.
 		if owners_needed() {
+			Self::prefetch_meta(&nodes);
 			Self::resolve_owners(&nodes, owner_man);
 		}
 		let owners = owner_man.owners();
 
 		Self::re_sort(&mut nodes, owners);
 
+		// Building a node's rows is independent, read-only work, so the
+		// top-level nodes are rendered in parallel; `collect` into an ordered
+		// `Vec` preserves the sorted order, and each subtree keeps its rows
+		// contiguous because a node owns the flattened rows of its descendants.
 		let entries = nodes
-			.iter()
-			.flat_map(|node| {
+			.par_iter()
+			.flat_map_iter(|node| {
 				node.entries(
 					owners,
 					&self.input.conf,
@@ -164,10 +172,24 @@ impl DirGroup {
 		}
 	}
 
+	/// Fetch and cache the metadata of every node in the given forest in
+	/// parallel.
+	///
+	/// Metadata is otherwise fetched lazily and serially; doing it up front in
+	/// parallel turns a sequence of blocking `stat` calls into concurrent ones
+	/// and ensures later owner resolution reads cached metadata.
+	fn prefetch_meta(nodes: &[Node]) {
+		nodes.par_iter().for_each(|node| {
+			node.meta_ok();
+			Self::prefetch_meta(&node.children);
+		});
+	}
+
 	/// Resolve the owning user and group of every node in the given forest.
 	///
-	/// This populates the [`OwnerMan`] cache up front so that rendering can look
-	/// owners up through an immutable [`Owners`] view without touching the cache.
+	/// This populates the (`!Sync`) [`OwnerMan`] cache serially so that the
+	/// parallel render can look owners up through an immutable [`Owners`] view
+	/// without touching the cache.
 	fn resolve_owners(nodes: &[Node], owner_man: &mut OwnerMan) {
 		for node in nodes {
 			if let Some(meta) = node.meta_ok() {

--- a/src/args/files_group.rs
+++ b/src/args/files_group.rs
@@ -1,10 +1,8 @@
 use crate::args::input::Input;
 use crate::config::{Conf, ConfMan};
-use crate::enums::DetailField;
 use crate::models::{Node, OwnerMan};
 use crate::utils::paths::common_ancestor;
 use log::debug;
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 // ======
@@ -54,7 +52,7 @@ impl FilesGroup {
 	/// Since individual nodes are not nested, the function uses each node's
 	/// [`Node::row`] instead of the flattened output of each node's
 	/// [`Node::entries`].
-	pub fn entries(&self, owner_man: &mut OwnerMan) -> Vec<HashMap<DetailField, String>> {
+	pub fn entries(&self, owner_man: &mut OwnerMan) -> Vec<Vec<String>> {
 		self.nodes()
 			.iter()
 			.map(|(node, conf)| {

--- a/src/args/files_group.rs
+++ b/src/args/files_group.rs
@@ -1,8 +1,10 @@
+use crate::args::dir_group::owners_needed;
 use crate::args::input::Input;
 use crate::config::{Conf, ConfMan};
 use crate::models::{Node, OwnerMan};
 use crate::utils::paths::common_ancestor;
 use log::debug;
+use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 
 // ======
@@ -53,11 +55,25 @@ impl FilesGroup {
 	/// [`Node::row`] instead of the flattened output of each node's
 	/// [`Node::entries`].
 	pub fn entries(&self, owner_man: &mut OwnerMan) -> Vec<Vec<String>> {
-		self.nodes()
+		let nodes = self.nodes();
+
+		// Resolve owners up front so rows can be built through an immutable
+		// owner view (see [`DirGroup::entries`]).
+		if owners_needed() {
+			for (node, _) in &nodes {
+				if let Some(meta) = node.meta_ok() {
+					owner_man.user(meta.uid());
+					owner_man.group(meta.gid());
+				}
+			}
+		}
+		let owners = owner_man.owners();
+
+		nodes
 			.iter()
 			.map(|(node, conf)| {
 				node.row(
-					owner_man,
+					owners,
 					conf,
 					&self.parent_conf.app_const,
 					&conf.entry_const,

--- a/src/args/group.rs
+++ b/src/args/group.rs
@@ -2,13 +2,12 @@ use crate::args::dir_group::DirGroup;
 use crate::args::files_group::FilesGroup;
 use crate::args::input::Input;
 use crate::config::{Conf, ConfMan};
-use crate::enums::{DetailField, Typ};
+use crate::enums::Typ;
 use crate::exc::Exc;
 use crate::fmt::render;
 use crate::models::OwnerMan;
 use crate::output::{Grid, Table};
 use crate::PLS;
-use std::collections::HashMap;
 
 // ======
 // Models
@@ -90,10 +89,7 @@ impl Group {
 
 	/// Convert this group into a vector of entries that can be passed into the
 	/// layout to be rendered.
-	pub fn entries(
-		&self,
-		owner_man: &mut OwnerMan,
-	) -> Result<Vec<HashMap<DetailField, String>>, Exc> {
+	pub fn entries(&self, owner_man: &mut OwnerMan) -> Result<Vec<Vec<String>>, Exc> {
 		match self {
 			Self::Dir(group) => group.entries(owner_man),
 			Self::Files(group) => Ok(group.entries(owner_man)),

--- a/src/config/app_const.rs
+++ b/src/config/app_const.rs
@@ -94,8 +94,8 @@ impl AppConst {
 			.map(|(k, v)| (*k, v.to_string()))
 			.collect();
 
-		self.imp_styles = self.imp_map.clone().into_iter().collect();
-		self.imp_styles.sort_by_cached_key(|entry| entry.0);
+		self.imp_styles = self.imp_map.iter().map(|(k, v)| (*k, v.clone())).collect();
+		self.imp_styles.sort_by_key(|entry| entry.0);
 	}
 
 	/// Get the lowest configured importance level, i.e. zeroth index in `imp`.

--- a/src/config/entry_const.rs
+++ b/src/config/entry_const.rs
@@ -1,4 +1,5 @@
 use crate::enums::{DetailField, Oct, Sym, SymState, Typ};
+use log::warn;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -50,11 +51,15 @@ impl EntryConst {
 			.get_or_init(|| {
 				self.timestamp_formats
 					.iter()
-					.filter_map(|(&field, fmt)| {
-						format_description::parse_owned::<2>(fmt)
-							.ok()
-							.map(|parsed| (field, parsed))
-					})
+					.filter_map(
+						|(&field, fmt)| match format_description::parse_owned::<2>(fmt) {
+							Ok(parsed) => Some((field, parsed)),
+							Err(err) => {
+								warn!("Could not parse timestamp format for {field:?}: {err}");
+								None
+							}
+						},
+					)
 					.collect()
 			})
 			.get(&field)

--- a/src/config/entry_const.rs
+++ b/src/config/entry_const.rs
@@ -1,6 +1,8 @@
 use crate::enums::{DetailField, Oct, Sym, SymState, Typ};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::OnceLock;
+use time::format_description::{self, OwnedFormatItem};
 
 #[derive(Serialize, Deserialize)]
 pub struct EntryConst {
@@ -28,6 +30,35 @@ pub struct EntryConst {
 	pub timestamp_formats: HashMap<DetailField, String>,
 	/// mapping of symlink state to more symlink state info (including style)
 	pub symlink: HashMap<SymState, SymlinkInfo>,
+
+	/// lazily-parsed counterpart of [`timestamp_formats`](Self::timestamp_formats)
+	///
+	/// Parsing a format description is relatively expensive, so each format is
+	/// parsed at most once for the lifetime of the config rather than once per
+	/// node per timestamp column.
+	#[serde(skip)]
+	timestamp_formats_parsed: OnceLock<HashMap<DetailField, OwnedFormatItem>>,
+}
+
+impl EntryConst {
+	/// Get the parsed format description for the given timestamp field.
+	///
+	/// The full set of formats is parsed once on first access and cached, so
+	/// subsequent timestamps reuse the already-parsed format.
+	pub fn timestamp_format(&self, field: DetailField) -> Option<&OwnedFormatItem> {
+		self.timestamp_formats_parsed
+			.get_or_init(|| {
+				self.timestamp_formats
+					.iter()
+					.filter_map(|(&field, fmt)| {
+						format_description::parse_owned::<2>(fmt)
+							.ok()
+							.map(|parsed| (field, parsed))
+					})
+					.collect()
+			})
+			.get(&field)
+	}
 }
 
 impl Default for EntryConst {
@@ -132,6 +163,7 @@ impl Default for EntryConst {
 				)
 			})
 			.collect(),
+			timestamp_formats_parsed: OnceLock::new(),
 		}
 	}
 }

--- a/src/enums/sort_field.rs
+++ b/src/enums/sort_field.rs
@@ -178,11 +178,11 @@ impl SortField {
 		use SortField::*;
 		// Map each reverse-order field (suffixed with '_') to its natural-order
 		// basis without allocating, which matters as this runs on every pairwise
-		// comparison during sorting. The `Self::from` calls cover the two cases
-		// whose names do not simply drop the trailing underscore.
+		// comparison during sorting. `Inode_` and `Nlinks_` are named differently
+		// from their natural counterparts, so they are mapped explicitly.
 		match self {
-			Inode_ => (Self::from("inode"), true),
-			Nlinks_ => (Self::from("nlinks"), true),
+			Inode_ => (Ino, true),
+			Nlinks_ => (Nlink, true),
 			Typ_ => (Typ, true),
 			Cat_ => (Cat, true),
 			User_ => (User, true),

--- a/src/enums/sort_field.rs
+++ b/src/enums/sort_field.rs
@@ -1,5 +1,5 @@
 use crate::enums::DetailField;
-use crate::models::{Node, OwnerMan};
+use crate::models::{Node, Owners};
 use crate::traits::{Detail, Name};
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
@@ -144,11 +144,11 @@ impl SortField {
 	///
 	/// This function handles reverse sort fields, the fields suffixed with '_',
 	/// by using the natural sort field's logic and then inverting it.
-	pub fn compare(&self, a: &Node, b: &Node, owner_man: &mut OwnerMan) -> Ordering {
+	pub fn compare(&self, a: &Node, b: &Node, owners: Owners) -> Ordering {
 		let (basis, is_reverse) = self.simplify();
 
 		let ord = basis
-			.compare_no_meta(a, b, owner_man)
+			.compare_no_meta(a, b, owners)
 			.or_else(|| basis.compare_meta(a, b))
 			.or_else(|| basis.compare_time(a, b))
 			.unwrap_or(Ordering::Equal);
@@ -206,15 +206,15 @@ impl SortField {
 	///
 	/// This function can perform comparisons based on fields that do not need
 	/// metadata at all, or account for the `meta` field being `Err`.
-	fn compare_no_meta(&self, a: &Node, b: &Node, owner_man: &mut OwnerMan) -> Option<Ordering> {
+	fn compare_no_meta(&self, a: &Node, b: &Node, owners: Owners) -> Option<Ordering> {
 		let ord = match self {
 			SortField::Name => a.name.cmp(&b.name),
 			SortField::Cname => a.cname().cmp(b.cname()),
 			SortField::Ext => a.ext().cmp(b.ext()),
 			SortField::Typ => a.typ.cmp(&b.typ),
 			SortField::Cat => a.typ.cat().cmp(&b.typ.cat()),
-			SortField::User => a.user_val(owner_man).cmp(&b.user_val(owner_man)),
-			SortField::Group => a.group_val(owner_man).cmp(&b.group_val(owner_man)),
+			SortField::User => a.user_val(owners).cmp(&b.user_val(owners)),
+			SortField::Group => a.group_val(owners).cmp(&b.group_val(owners)),
 			_ => return None,
 		};
 		Some(ord)

--- a/src/enums/sort_field.rs
+++ b/src/enums/sort_field.rs
@@ -175,11 +175,30 @@ impl SortField {
 	/// * the basis for the field, the natural order field corresponding to this
 	/// * whether the field is reversed from the natural order
 	fn simplify(&self) -> (Self, bool) {
-		let name = self.to_string();
-		if name.ends_with('_') {
-			(name.trim_end_matches('_').into(), true)
-		} else {
-			(*self, false)
+		use SortField::*;
+		// Map each reverse-order field (suffixed with '_') to its natural-order
+		// basis without allocating, which matters as this runs on every pairwise
+		// comparison during sorting. The `Self::from` calls cover the two cases
+		// whose names do not simply drop the trailing underscore.
+		match self {
+			Inode_ => (Self::from("inode"), true),
+			Nlinks_ => (Self::from("nlinks"), true),
+			Typ_ => (Typ, true),
+			Cat_ => (Cat, true),
+			User_ => (User, true),
+			Uid_ => (Uid, true),
+			Group_ => (Group, true),
+			Gid_ => (Gid, true),
+			Size_ => (Size, true),
+			Blocks_ => (Blocks, true),
+			Btime_ => (Btime, true),
+			Ctime_ => (Ctime, true),
+			Mtime_ => (Mtime, true),
+			Atime_ => (Atime, true),
+			Name_ => (Name, true),
+			Cname_ => (Cname, true),
+			Ext_ => (Ext, true),
+			other => (*other, false),
 		}
 	}
 

--- a/src/enums/sort_field.rs
+++ b/src/enums/sort_field.rs
@@ -209,8 +209,8 @@ impl SortField {
 	fn compare_no_meta(&self, a: &Node, b: &Node, owner_man: &mut OwnerMan) -> Option<Ordering> {
 		let ord = match self {
 			SortField::Name => a.name.cmp(&b.name),
-			SortField::Cname => a.cname().cmp(&b.cname()),
-			SortField::Ext => a.ext().cmp(&b.ext()),
+			SortField::Cname => a.cname().cmp(b.cname()),
+			SortField::Ext => a.ext().cmp(b.ext()),
 			SortField::Typ => a.typ.cmp(&b.typ),
 			SortField::Cat => a.typ.cat().cmp(&b.typ.cat()),
 			SortField::User => a.user_val(owner_man).cmp(&b.user_val(owner_man)),

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -18,4 +18,4 @@
 mod format;
 mod markup;
 
-pub use markup::{len, render};
+pub use markup::{len, render, render_and_measure};

--- a/src/fmt/format.rs
+++ b/src/fmt/format.rs
@@ -1,5 +1,6 @@
 use colored::{Color, ColoredString, Colorize};
 use regex::Regex;
+use std::borrow::Cow;
 use std::sync::LazyLock;
 
 static TRUE_COLOR: LazyLock<Regex> = LazyLock::new(|| {
@@ -60,9 +61,15 @@ fn apply_directive(string: ColoredString, directive: &str) -> ColoredString {
 	};
 
 	let is_bg = directive.starts_with("bg:");
-	let directive = directive.replace("bg:", "").replace("bright_", "bright ");
+	// Only allocate a new string when there is actually something to rewrite;
+	// the vast majority of directives (plain styles and colours) need neither.
+	let directive: Cow<str> = if is_bg || directive.contains("bright_") {
+		Cow::Owned(directive.replace("bg:", "").replace("bright_", "bright "))
+	} else {
+		Cow::Borrowed(directive)
+	};
 
-	let string = match directive.as_str() {
+	let string = match directive.as_ref() {
 		"clear" => return string.clear(), // no style
 		"blink" => return string.blink(),
 		"bold" => return string.bold(),
@@ -76,7 +83,7 @@ fn apply_directive(string: ColoredString, directive: &str) -> ColoredString {
 	};
 
 	let mut color: Option<Color> = None;
-	let caps = TRUE_COLOR.captures(&directive);
+	let caps = TRUE_COLOR.captures(directive.as_ref());
 	if let Some(caps) = caps {
 		// RGB true colors
 		let channels: Vec<_> = vec!["red", "green", "blue"]

--- a/src/fmt/markup.rs
+++ b/src/fmt/markup.rs
@@ -1,29 +1,9 @@
 use crate::fmt::format::fmt;
-use std::iter::Peekable;
-use std::str::Chars;
 use unicode_segmentation::UnicodeSegmentation;
 
-const ESCAPE: char = '\\';
-const TAG_OPEN: char = '<';
-const TAG_CLOSE: char = '>';
-
-/// Given a peekable iterable of characters, get a string comprised of all
-/// characters that satisfy the given condition.
-///
-/// # Arguments
-///
-/// * `tokens` - the peekable iterator of characters to consume from
-/// * `predicate` - the condition each character must satisfy to be consumed
-fn select_while<F>(tokens: &mut Peekable<Chars>, predicate: F) -> String
-where
-	F: Fn(char) -> bool,
-{
-	let mut selected = String::new();
-	while tokens.peek().is_some_and(|ch| predicate(*ch)) {
-		selected.push(tokens.next().unwrap());
-	}
-	selected
-}
+const ESCAPE: u8 = b'\\';
+const TAG_OPEN: u8 = b'<';
+const TAG_CLOSE: u8 = b'>';
 
 /// Reduce the textual parts of a markup string.
 ///
@@ -40,45 +20,56 @@ where
 /// * `markup` - the marked-up string to be reduced
 /// * `init` - the initial value of the accumulator
 /// * `reducer` - the function that works on the aforementioned data
-fn reduce_markup<S, T, F>(markup: S, init: T, reducer: F) -> T
+fn reduce_markup<'a, T, F>(markup: &'a str, init: T, reducer: F) -> T
 where
-	S: AsRef<str>,
-	F: Fn(&Vec<Vec<String>>, &mut String, T) -> T,
+	F: Fn(&[Vec<&'a str>], &mut String, T) -> T,
 {
-	let mut stack: Vec<Vec<String>> = Vec::new(); // the list of currently active tags
+	let mut stack: Vec<Vec<&'a str>> = Vec::new(); // the list of currently active tags
 	let mut curr: String = String::default(); // the current continuous text block
 
 	let mut acc = init; // initialise the accumulator
 
-	let mut tokens = markup.as_ref().chars().peekable();
-	while let Some(next_char) = tokens.peek() {
-		match *next_char {
+	// The delimiters (`<`, `>`, `\`) are all ASCII, so they never appear inside
+	// a multi-byte UTF-8 sequence. This lets us scan and slice on byte offsets
+	// and borrow tag tokens directly from the input instead of allocating.
+	let bytes = markup.as_bytes();
+	let mut i = 0;
+	while i < bytes.len() {
+		match bytes[i] {
 			ESCAPE => {
-				tokens.next(); // Consume `BACKSLASH`.
-				match tokens.peek() {
-					Some(then_char) if *then_char == TAG_OPEN => {
-						curr.push(TAG_OPEN);
-						tokens.next(); // Consume `TAG_OPEN`.
-					}
-					_ => curr.push(ESCAPE),
+				i += 1; // Consume `BACKSLASH`.
+				if bytes.get(i) == Some(&TAG_OPEN) {
+					curr.push(TAG_OPEN as char);
+					i += 1; // Consume `TAG_OPEN`.
+				} else {
+					curr.push(ESCAPE as char);
 				}
 			}
 			TAG_OPEN => {
 				// Handle the current run of continuous text.
 				acc = reducer(&stack, &mut curr, acc);
 
-				tokens.next(); // Consume `TAG_OPEN`.
-				let tag = select_while(&mut tokens, |c| c != TAG_CLOSE);
+				i += 1; // Consume `TAG_OPEN`.
+				let start = i;
+				while i < bytes.len() && bytes[i] != TAG_CLOSE {
+					i += 1;
+				}
+				let tag = &markup[start..i];
 				if tag == "/" {
 					stack.pop();
 				} else {
-					stack.push(tag.split(' ').map(String::from).collect());
+					stack.push(tag.split(' ').collect());
 				}
-				tokens.next(); // Consume `TAG_CLOSE`.
+				if i < bytes.len() {
+					i += 1; // Consume `TAG_CLOSE`.
+				}
 			}
 			_ => {
-				let text = select_while(&mut tokens, |c| c != TAG_OPEN && c != ESCAPE);
-				curr.push_str(&text);
+				let start = i;
+				while i < bytes.len() && bytes[i] != TAG_OPEN && bytes[i] != ESCAPE {
+					i += 1;
+				}
+				curr.push_str(&markup[start..i]);
 			}
 		}
 	}
@@ -100,11 +91,11 @@ pub fn render<S>(markup: S) -> String
 where
 	S: AsRef<str>,
 {
-	reduce_markup(markup, String::default(), |stack, curr, acc| {
+	reduce_markup(markup.as_ref(), String::default(), |stack, curr, acc| {
 		let mut acc = acc;
 		if !curr.is_empty() {
-			let directives: Vec<_> = stack.iter().flatten().collect();
-			if !directives.iter().any(|tag| tag.as_str() == "hidden") {
+			let directives: Vec<&str> = stack.iter().flatten().copied().collect();
+			if !directives.contains(&"hidden") {
 				acc.push_str(&fmt(&curr, &directives));
 			}
 			curr.clear();
@@ -125,8 +116,8 @@ pub fn len<S>(markup: S) -> usize
 where
 	S: AsRef<str>,
 {
-	reduce_markup(markup, 0, |stack, curr, acc| {
-		let count = if curr.is_empty() || stack.iter().flatten().any(|tag| tag == "hidden") {
+	reduce_markup(markup.as_ref(), 0, |stack, curr, acc| {
+		let count = if curr.is_empty() || stack.iter().flatten().any(|tag| *tag == "hidden") {
 			0
 		} else {
 			curr.graphemes(true).count()
@@ -138,26 +129,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use super::{len, render, select_while};
-
-	macro_rules! make_select_while_test {
-        ( $($name:ident: $predicate:expr => $selected:expr,)* ) => {
-            $(
-                #[test]
-                fn $name() {
-					colored::control::set_override(true); // needed when running tests in CLion
-                    let mut tokens = "Hello, World!".chars().peekable();
-                    let selected = select_while(&mut tokens, $predicate);
-                    assert_eq!(selected, $selected);
-                }
-            )*
-        };
-    }
-
-	make_select_while_test!(
-		test_select_selects_part_of_string: |c| c != ',' => "Hello",
-		test_select_consumes_till_end_of_string: |c| c != '?' => "Hello, World!",
-	);
+	use super::{len, render};
 
 	macro_rules! make_render_test {
         ( $($name:ident: $markup:expr => $rendered:expr,)* ) => {

--- a/src/fmt/markup.rs
+++ b/src/fmt/markup.rs
@@ -222,7 +222,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use super::{len, render};
+	use super::{len, render, render_and_measure};
 
 	macro_rules! make_render_test {
         ( $($name:ident: $markup:expr => $rendered:expr,)* ) => {
@@ -286,5 +286,30 @@ mod tests {
 
 		test_len_ignores_tags: "<bold>bold</>" => 4,
 		test_len_drops_hidden_text: "<blue>blue<hidden>hidden</></>" => 4,
+	);
+
+	macro_rules! make_render_and_measure_test {
+		( $($name:ident: $markup:expr,)* ) => {
+			$(
+				#[test]
+				fn $name() {
+					colored::control::set_override(true); // needed when running tests in CLion
+					// The single-pass helper must stay equivalent to calling
+					// `render` and `len` separately.
+					assert_eq!(render_and_measure($markup), (render($markup), len($markup)));
+				}
+			)*
+		};
+	}
+
+	make_render_and_measure_test!(
+		test_render_and_measure_matches_plain: "plain text",
+		test_render_and_measure_matches_single_style: "<bold>bold</>",
+		test_render_and_measure_matches_multiple_styles: "<bold italic>bold italic</>",
+		test_render_and_measure_matches_nested_tags: "<blue><italic>blue italic</> blue</>",
+		test_render_and_measure_matches_trailing_text: "<bold>bold</> trailing",
+		test_render_and_measure_matches_hidden_text: "<blue>blue<hidden>hidden</></>",
+		test_render_and_measure_matches_escaped_tags: "\\<bold>\\bold",
+		test_render_and_measure_matches_unicode: "<bold>मैं</> 🤦🏽‍♂️",
 	);
 }

--- a/src/fmt/markup.rs
+++ b/src/fmt/markup.rs
@@ -1,9 +1,69 @@
 use crate::fmt::format::fmt;
+use crate::gfx::strip_image;
+use std::cell::RefCell;
+use std::collections::HashMap;
 use unicode_segmentation::UnicodeSegmentation;
 
 const ESCAPE: u8 = b'\\';
 const TAG_OPEN: u8 = b'<';
 const TAG_CLOSE: u8 = b'>';
+
+thread_local! {
+	/// Per-thread cache of the ANSI prefix/suffix for a set of formatting
+	/// directives.
+	///
+	/// The set of distinct directive combinations is tiny (it is drawn from the
+	/// config vocabulary), so memoising the affixes lets the hot path avoid
+	/// rebuilding a `ColoredString` for every styled run while still producing
+	/// byte-identical output to the underlying `colored` crate.
+	static AFFIX_CACHE: RefCell<HashMap<String, (String, String)>> = RefCell::new(HashMap::new());
+}
+
+/// A sentinel that cannot appear in user text, used to recover the prefix and
+/// suffix that `colored` wraps around a styled run.
+const AFFIX_SENTINEL: &str = "\u{1}";
+
+/// Compute the ANSI prefix and suffix that `colored` applies for `directives`.
+///
+/// `colored` always wraps text as `{prefix}{text}{suffix}` with the affixes
+/// independent of the text itself, so rendering a sentinel and splitting on it
+/// recovers them exactly.
+fn compute_affixes(directives: &[&str]) -> (String, String) {
+	let rendered = fmt(AFFIX_SENTINEL, directives);
+	match rendered.split_once(AFFIX_SENTINEL) {
+		Some((prefix, suffix)) => (prefix.to_string(), suffix.to_string()),
+		None => (String::new(), String::new()),
+	}
+}
+
+/// Append `text` to `out`, wrapped in the ANSI affixes for `directives`.
+fn write_run(out: &mut String, directives: &[&str], text: &str) {
+	if directives.is_empty() {
+		out.push_str(text);
+		return;
+	}
+	AFFIX_CACHE.with(|cache| {
+		let mut cache = cache.borrow_mut();
+		let (prefix, suffix) = cache
+			.entry(directives.join("\u{1f}"))
+			.or_insert_with(|| compute_affixes(directives));
+		out.push_str(prefix);
+		out.push_str(text);
+		out.push_str(suffix);
+	});
+}
+
+/// Count the display width (in graphemes) of a styled run, excluding any
+/// embedded terminal-graphics escape sequences.
+fn run_width(text: &str) -> usize {
+	// Terminal-graphics escapes always begin with the ESC byte, so when none is
+	// present the (relatively costly) image strip can be skipped entirely.
+	if text.as_bytes().contains(&0x1b) {
+		strip_image(text).graphemes(true).count()
+	} else {
+		text.graphemes(true).count()
+	}
+}
 
 /// Reduce the textual parts of a markup string.
 ///
@@ -86,22 +146,55 @@ where
 /// # Arguments
 ///
 /// * `markup` - the marked-up string to be rendered
-#[allow(clippy::needless_borrows_for_generic_args)]
 pub fn render<S>(markup: S) -> String
 where
 	S: AsRef<str>,
 {
-	reduce_markup(markup.as_ref(), String::default(), |stack, curr, acc| {
-		let mut acc = acc;
-		if !curr.is_empty() {
-			let directives: Vec<&str> = stack.iter().flatten().copied().collect();
-			if !directives.contains(&"hidden") {
-				acc.push_str(&fmt(&curr, &directives));
+	reduce_markup(
+		markup.as_ref(),
+		String::default(),
+		|stack, curr, mut acc| {
+			if !curr.is_empty() {
+				let directives: Vec<&str> = stack.iter().flatten().copied().collect();
+				if !directives.contains(&"hidden") {
+					write_run(&mut acc, &directives, curr);
+				}
+				curr.clear();
 			}
-			curr.clear();
-		}
-		acc
-	})
+			acc
+		},
+	)
+}
+
+/// Render the given markup string into ANSI escape codes and measure its
+/// rendered width in a single pass.
+///
+/// This is equivalent to calling [`render`] and [`len`] separately but parses
+/// the markup only once, which matters because every rendered cell needs both
+/// its ANSI form (to print) and its display width (to align columns).
+///
+/// # Arguments
+///
+/// * `markup` - the marked-up string to be rendered and measured
+pub fn render_and_measure<S>(markup: S) -> (String, usize)
+where
+	S: AsRef<str>,
+{
+	reduce_markup(
+		markup.as_ref(),
+		(String::new(), 0_usize),
+		|stack, curr, (mut text, mut width)| {
+			if !curr.is_empty() {
+				let directives: Vec<&str> = stack.iter().flatten().copied().collect();
+				if !directives.contains(&"hidden") {
+					width += run_width(curr);
+					write_run(&mut text, &directives, curr);
+				}
+				curr.clear();
+			}
+			(text, width)
+		},
+	)
 }
 
 /// Get the true length of a markup string.

--- a/src/fmt/markup.rs
+++ b/src/fmt/markup.rs
@@ -104,7 +104,7 @@ where
 		let mut acc = acc;
 		if !curr.is_empty() {
 			let directives: Vec<_> = stack.iter().flatten().collect();
-			if !directives.contains(&&String::from("hidden")) {
+			if !directives.iter().any(|tag| tag.as_str() == "hidden") {
 				acc.push_str(&fmt(&curr, &directives));
 			}
 			curr.clear();

--- a/src/gfx/kitty.rs
+++ b/src/gfx/kitty.rs
@@ -4,6 +4,7 @@ use base64::prelude::*;
 use crossterm::terminal::*;
 use log::debug;
 use regex::Regex;
+use std::borrow::Cow;
 use std::env;
 use std::sync::LazyLock;
 
@@ -127,14 +128,15 @@ pub fn render_image(id: u32, size: u8, count: u8) -> String {
 /// # Arguments
 ///
 /// * `text` - the text to strip the image data from
-pub fn strip_image<S>(text: S) -> String
-where
-	S: AsRef<str>,
-{
-	KITTY_IMAGE
-		.replace_all(text.as_ref(), "")
-		.replace("\x1b[2C", "  ")
-		.to_string()
+pub fn strip_image(text: &str) -> Cow<'_, str> {
+	// `replace_all` borrows the input unchanged when there is no image, so the
+	// common (image-free) case allocates nothing.
+	let stripped = KITTY_IMAGE.replace_all(text, "");
+	if stripped.contains("\x1b[2C") {
+		Cow::Owned(stripped.replace("\x1b[2C", "  "))
+	} else {
+		stripped
+	}
 }
 
 /// Perform the given query in the terminal raw mode.
@@ -162,6 +164,6 @@ mod tests {
 	#[test]
 	fn test_remove_image_substrings() {
 		let text = "\x1b_Gf=32;AAAA\x1b\\Hello, World!";
-		assert_eq!(strip_image(text), "Hello, World!");
+		assert_eq!(strip_image(text).as_ref(), "Hello, World!");
 	}
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -6,7 +6,7 @@ mod spec;
 mod window;
 
 pub use node::Node;
-pub use owner::OwnerMan;
+pub use owner::{OwnerMan, Owners};
 pub use perm::Perm;
 pub use pls::Pls;
 pub use spec::Spec;

--- a/src/models/node.rs
+++ b/src/models/node.rs
@@ -3,7 +3,6 @@ use crate::enums::{Appearance, Collapse, DetailField, Icon, Typ};
 use crate::models::{Owners, Spec};
 use crate::traits::{Detail, Imp, Name, Sym};
 use crate::PLS;
-use std::cell::OnceCell;
 use std::collections::HashSet;
 use std::fmt::Write;
 use std::fmt::{Display, Formatter, Result as FmtResult};
@@ -11,6 +10,7 @@ use std::fs::{DirEntry, Metadata};
 use std::io::Result as IoResult;
 use std::iter::once;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 pub struct Node<'pls> {
 	/// the name of the node on the file system, determined from the path and
@@ -23,7 +23,7 @@ pub struct Node<'pls> {
 	pub path: PathBuf,
 	/// the node's metadata, fetched lazily on first access via [`Node::meta_ok`]
 	/// so that views which do not need it (e.g. the grid) never pay for a stat
-	meta: OnceCell<IoResult<Metadata>>,
+	meta: OnceLock<IoResult<Metadata>>,
 	pub typ: Typ, // `Typ::Unknown` if the type could not be determined
 
 	pub appearances: HashSet<Appearance>,
@@ -34,9 +34,9 @@ pub struct Node<'pls> {
 	pub children: Vec<Node<'pls>>,
 
 	/// cached canonical name, computed once for sorting (see [`Name::cname`])
-	pub(crate) cname_cache: OnceCell<String>,
+	pub(crate) cname_cache: OnceLock<String>,
 	/// cached extension, computed once for sorting (see [`Name::ext`])
-	pub(crate) ext_cache: OnceCell<String>,
+	pub(crate) ext_cache: OnceLock<String>,
 }
 
 impl<'pls> Node<'pls> {
@@ -60,7 +60,7 @@ impl<'pls> Node<'pls> {
 			.as_ref()
 			.map(|meta| meta.file_type().into())
 			.unwrap_or(Typ::Unknown);
-		let meta = OnceCell::new();
+		let meta = OnceLock::new();
 		let _ = meta.set(meta_res);
 
 		Self::assemble(name, path, meta, typ)
@@ -77,11 +77,11 @@ impl<'pls> Node<'pls> {
 		let path = entry.path();
 		let typ = entry.file_type().map(Typ::from).unwrap_or(Typ::Unknown);
 
-		Self::assemble(name, path, OnceCell::new(), typ)
+		Self::assemble(name, path, OnceLock::new(), typ)
 	}
 
 	/// Assemble a `Node` from its already-derived core fields.
-	fn assemble(name: String, path: PathBuf, meta: OnceCell<IoResult<Metadata>>, typ: Typ) -> Self {
+	fn assemble(name: String, path: PathBuf, meta: OnceLock<IoResult<Metadata>>, typ: Typ) -> Self {
 		let display_name = name.clone();
 		Self {
 			name,
@@ -93,8 +93,8 @@ impl<'pls> Node<'pls> {
 			specs: vec![],
 			collapse_name: None,
 			children: vec![],
-			cname_cache: OnceCell::new(),
-			ext_cache: OnceCell::new(),
+			cname_cache: OnceLock::new(),
+			ext_cache: OnceLock::new(),
 		}
 	}
 

--- a/src/models/node.rs
+++ b/src/models/node.rs
@@ -4,7 +4,7 @@ use crate::models::{OwnerMan, Spec};
 use crate::traits::{Detail, Imp, Name, Sym};
 use crate::PLS;
 use std::cell::OnceCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::Write;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::fs::{DirEntry, Metadata};
@@ -379,9 +379,11 @@ impl<'pls> Node<'pls> {
 		val.unwrap_or_default()
 	}
 
-	/// Get a mapping of detail fields to their values.
+	/// Get the values of the chosen detail fields, in their configured order.
 	///
-	/// This information is used to render the table row for a node.
+	/// The values are returned positionally, aligned with
+	/// [`PLS.args.details`](crate::config::Args::details), which lets the layout
+	/// index into the row by position instead of hashing a `DetailField` key.
 	pub fn row(
 		&self,
 		owner_man: &mut OwnerMan,
@@ -389,26 +391,24 @@ impl<'pls> Node<'pls> {
 		app_const: &AppConst,
 		entry_const: &EntryConst,
 		tree_shape: &[&str],
-	) -> HashMap<DetailField, String> {
+	) -> Vec<String> {
 		PLS.args
 			.details
 			.iter()
 			.map(|&detail| {
 				if detail == DetailField::Name {
-					(
-						detail,
-						self.display_name(conf, app_const, entry_const, tree_shape),
-					)
+					self.display_name(conf, app_const, entry_const, tree_shape)
 				} else {
-					(detail, self.get_value(detail, owner_man, entry_const))
+					self.get_value(detail, owner_man, entry_const)
 				}
 			})
 			.collect()
 	}
 
-	/// Get a vector of mapping of detail fields to their values.
+	/// Get a vector of rows, one per node in this subtree.
 	///
-	/// Each entry in the vector is a row that can be used to render a table.
+	/// Each row is a positional list of detail-field values that can be used to
+	/// render a table.
 	///
 	#[allow(clippy::too_many_arguments)]
 	pub fn entries(
@@ -419,7 +419,7 @@ impl<'pls> Node<'pls> {
 		entry_const: &EntryConst,
 		parent_shapes: &[&str],  // list of shapes inherited from the parent
 		own_shape: Option<&str>, // shape to show just before the current node
-	) -> Vec<HashMap<DetailField, String>> {
+	) -> Vec<Vec<String>> {
 		// list of parent shapes to pass to the children
 		let mut child_parent_shapes = parent_shapes.to_vec();
 

--- a/src/models/node.rs
+++ b/src/models/node.rs
@@ -1,6 +1,6 @@
 use crate::config::{AppConst, Conf, EntryConst};
 use crate::enums::{Appearance, Collapse, DetailField, Icon, Typ};
-use crate::models::{OwnerMan, Spec};
+use crate::models::{Owners, Spec};
 use crate::traits::{Detail, Imp, Name, Sym};
 use crate::PLS;
 use std::cell::OnceCell;
@@ -349,12 +349,7 @@ impl<'pls> Node<'pls> {
 	// Printer entry
 	// =============
 
-	fn get_value(
-		&self,
-		detail: DetailField,
-		owner_man: &mut OwnerMan,
-		entry_const: &EntryConst,
-	) -> String {
+	fn get_value(&self, detail: DetailField, owners: Owners, entry_const: &EntryConst) -> String {
 		let val = match detail {
 			// `Detail` trait
 			DetailField::Dev => self.dev(entry_const),
@@ -362,10 +357,10 @@ impl<'pls> Node<'pls> {
 			DetailField::Nlink => self.nlink(entry_const),
 			DetailField::Perm => self.perm(entry_const),
 			DetailField::Oct => self.oct(entry_const),
-			DetailField::User => self.user(owner_man, entry_const),
-			DetailField::Uid => self.uid(owner_man, entry_const),
-			DetailField::Group => self.group(owner_man, entry_const),
-			DetailField::Gid => self.gid(owner_man, entry_const),
+			DetailField::User => self.user(owners, entry_const),
+			DetailField::Uid => self.uid(owners, entry_const),
+			DetailField::Group => self.group(owners, entry_const),
+			DetailField::Gid => self.gid(owners, entry_const),
 			DetailField::Btime => self.time(detail, entry_const),
 			DetailField::Mtime => self.time(detail, entry_const),
 			DetailField::Ctime => self.time(detail, entry_const),
@@ -386,7 +381,7 @@ impl<'pls> Node<'pls> {
 	/// index into the row by position instead of hashing a `DetailField` key.
 	pub fn row(
 		&self,
-		owner_man: &mut OwnerMan,
+		owners: Owners,
 		conf: &Conf,
 		app_const: &AppConst,
 		entry_const: &EntryConst,
@@ -399,7 +394,7 @@ impl<'pls> Node<'pls> {
 				if detail == DetailField::Name {
 					self.display_name(conf, app_const, entry_const, tree_shape)
 				} else {
-					self.get_value(detail, owner_man, entry_const)
+					self.get_value(detail, owners, entry_const)
 				}
 			})
 			.collect()
@@ -413,7 +408,7 @@ impl<'pls> Node<'pls> {
 	#[allow(clippy::too_many_arguments)]
 	pub fn entries(
 		&self,
-		owner_man: &mut OwnerMan,
+		owners: Owners,
 		conf: &Conf,
 		app_const: &AppConst,
 		entry_const: &EntryConst,
@@ -439,7 +434,7 @@ impl<'pls> Node<'pls> {
 			all_shapes.push(more_shape);
 		}
 
-		once(self.row(owner_man, conf, app_const, entry_const, &all_shapes))
+		once(self.row(owners, conf, app_const, entry_const, &all_shapes))
 			.chain(self.children.iter().enumerate().flat_map(|(idx, child)| {
 				let child_own_shape = if idx == self.children.len() - 1 {
 					&app_const.tree.bend_dash
@@ -448,7 +443,7 @@ impl<'pls> Node<'pls> {
 				};
 
 				child.entries(
-					owner_man,
+					owners,
 					conf,
 					app_const,
 					entry_const,

--- a/src/models/node.rs
+++ b/src/models/node.rs
@@ -32,6 +32,11 @@ pub struct Node<'pls> {
 
 	pub collapse_name: Option<String>,
 	pub children: Vec<Node<'pls>>,
+
+	/// cached canonical name, computed once for sorting (see [`Name::cname`])
+	pub(crate) cname_cache: OnceCell<String>,
+	/// cached extension, computed once for sorting (see [`Name::ext`])
+	pub(crate) ext_cache: OnceCell<String>,
 }
 
 impl<'pls> Node<'pls> {
@@ -88,6 +93,8 @@ impl<'pls> Node<'pls> {
 			specs: vec![],
 			collapse_name: None,
 			children: vec![],
+			cname_cache: OnceCell::new(),
+			ext_cache: OnceCell::new(),
 		}
 	}
 

--- a/src/models/node.rs
+++ b/src/models/node.rs
@@ -3,10 +3,11 @@ use crate::enums::{Appearance, Collapse, DetailField, Icon, Typ};
 use crate::models::{OwnerMan, Spec};
 use crate::traits::{Detail, Imp, Name, Sym};
 use crate::PLS;
+use std::cell::OnceCell;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::fs::Metadata;
+use std::fs::{DirEntry, Metadata};
 use std::io::Result as IoResult;
 use std::iter::once;
 use std::path::{Path, PathBuf};
@@ -20,8 +21,10 @@ pub struct Node<'pls> {
 	pub display_name: String,
 
 	pub path: PathBuf,
-	meta: IoResult<Metadata>,
-	pub typ: Typ, // `Typ::Unknown` if `meta` is `Err`
+	/// the node's metadata, fetched lazily on first access via [`Node::meta_ok`]
+	/// so that views which do not need it (e.g. the grid) never pay for a stat
+	meta: OnceCell<IoResult<Metadata>>,
+	pub typ: Typ, // `Typ::Unknown` if the type could not be determined
 
 	pub appearances: HashSet<Appearance>,
 
@@ -42,12 +45,39 @@ impl<'pls> Node<'pls> {
 			.unwrap_or_default()
 			.to_string_lossy()
 			.to_string();
-		let display_name = name.clone();
-
 		let path = path.to_owned();
-		let meta = path.symlink_metadata();
-		let typ = path.as_path().try_into().unwrap_or(Typ::Unknown);
 
+		// There is no directory entry to read `d_type` from here, so a stat is
+		// unavoidable to determine the type. Perform it once and seed the cache
+		// so that later metadata access does not stat the path a second time.
+		let meta_res = path.symlink_metadata();
+		let typ = meta_res
+			.as_ref()
+			.map(|meta| meta.file_type().into())
+			.unwrap_or(Typ::Unknown);
+		let meta = OnceCell::new();
+		let _ = meta.set(meta_res);
+
+		Self::assemble(name, path, meta, typ)
+	}
+
+	/// Create a `Node` from a directory entry.
+	///
+	/// The entry's type is read from the `d_type` returned inline by the
+	/// directory read, avoiding a `stat` syscall on filesystems that provide it.
+	/// Metadata is left unfetched and is loaded lazily only if a detail field
+	/// needs it.
+	pub fn from_entry(entry: &DirEntry) -> Self {
+		let name = entry.file_name().to_string_lossy().to_string();
+		let path = entry.path();
+		let typ = entry.file_type().map(Typ::from).unwrap_or(Typ::Unknown);
+
+		Self::assemble(name, path, OnceCell::new(), typ)
+	}
+
+	/// Assemble a `Node` from its already-derived core fields.
+	fn assemble(name: String, path: PathBuf, meta: OnceCell<IoResult<Metadata>>, typ: Typ) -> Self {
+		let display_name = name.clone();
 		Self {
 			name,
 			display_name,
@@ -109,8 +139,14 @@ impl<'pls> Node<'pls> {
 	// =======
 
 	/// Get the metadata of the node if it was successfully retrieved.
+	///
+	/// The metadata is fetched on first access and cached, so views that never
+	/// call this (such as the grid) avoid the `stat` syscall entirely.
 	pub fn meta_ok(&self) -> Option<&Metadata> {
-		self.meta.as_ref().ok()
+		self.meta
+			.get_or_init(|| self.path.symlink_metadata())
+			.as_ref()
+			.ok()
 	}
 
 	// =========

--- a/src/models/node.rs
+++ b/src/models/node.rs
@@ -16,9 +16,8 @@ pub struct Node<'pls> {
 	/// the name of the node on the file system, determined from the path and
 	/// lossily converted into a string
 	pub name: String,
-	/// the name of the node to show to the user, equal to the `name` unless
-	/// overridden by an appearance mode
-	pub display_name: String,
+	/// an override for the name shown to the user, set by an appearance mode
+	pub override_name: Option<String>,
 
 	pub path: PathBuf,
 	/// the node's metadata, fetched lazily on first access via [`Node::meta_ok`]
@@ -82,10 +81,9 @@ impl<'pls> Node<'pls> {
 
 	/// Assemble a `Node` from its already-derived core fields.
 	fn assemble(name: String, path: PathBuf, meta: OnceLock<IoResult<Metadata>>, typ: Typ) -> Self {
-		let display_name = name.clone();
 		Self {
 			name,
-			display_name,
+			override_name: None,
 			path,
 			meta,
 			typ,
@@ -108,7 +106,7 @@ impl<'pls> Node<'pls> {
 	/// the name hardcoded. It should be used to change the name to something
 	/// different from the name derived from the path.
 	pub fn solo_file(mut self, name: String) -> Self {
-		self.display_name = name;
+		self.override_name = Some(name);
 		self.appearances.insert(Appearance::SoloFile);
 		self
 	}
@@ -119,7 +117,7 @@ impl<'pls> Node<'pls> {
 	/// the name hardcoded. It should be used to change the name to something
 	/// different from the name derived from the path.
 	pub fn symlink(mut self, name: String) -> Self {
-		self.display_name = name;
+		self.override_name = Some(name);
 		self.appearances.insert(Appearance::Symlink);
 		self
 	}
@@ -154,6 +152,14 @@ impl<'pls> Node<'pls> {
 			.get_or_init(|| self.path.symlink_metadata())
 			.as_ref()
 			.ok()
+	}
+
+	/// Get the name to show to the user.
+	///
+	/// This is the appearance-mode override if one was set or the node's name
+	/// borrowed without allocating.
+	pub fn disp_name(&self) -> &str {
+		self.override_name.as_deref().unwrap_or(&self.name)
 	}
 
 	// =========
@@ -227,7 +233,7 @@ impl<'pls> Node<'pls> {
 			let imp_dir = Imp::directives(self, app_const);
 			if let Some(directive) = imp_dir {
 				directives.push(' ');
-				directives.push_str(&directive);
+				directives.push_str(directive);
 			}
 		}
 
@@ -326,7 +332,7 @@ impl<'pls> Node<'pls> {
 			|| self.appearances.contains(&Appearance::Symlink)
 			|| self.appearances.contains(&Appearance::SoloFile)
 		{
-			parts.push_str(&self.display_name)
+			parts.push_str(self.disp_name())
 		} else {
 			parts.push_str(&self.aligned_name())
 		}

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -58,7 +58,7 @@ impl OwnerMan {
 				entity: Entity::Group,
 				id: gid,
 				name: Some(group.name().to_string_lossy().into()),
-				is_curr: self.curr_user.clone().is_some_and(|user| {
+				is_curr: self.curr_user.as_ref().is_some_and(|user| {
 					group
 						.members()
 						.iter()

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -98,6 +98,42 @@ impl OwnerMan {
 		}
 		&self.groups[&gid]
 	}
+
+	/// Get an immutable, shareable view over the already-resolved owners.
+	///
+	/// [`OwnerMan`] holds a `!Sync` user/group cache, so it cannot be shared
+	/// across threads. Once every owner a render needs has been resolved (see
+	/// [`Self::user`] and [`Self::group`]), this borrows just the resolved maps,
+	/// which *are* `Sync`, so the per-node rendering can run in parallel.
+	pub fn owners(&self) -> Owners<'_> {
+		Owners {
+			users: &self.users,
+			groups: &self.groups,
+		}
+	}
+}
+
+/// An immutable, thread-shareable view over resolved [`Owner`] instances.
+///
+/// Unlike [`OwnerMan`], this performs no lookups of its own — every owner must
+/// already have been resolved — which keeps it free of the `!Sync` user/group
+/// cache and therefore safe to share across rendering threads.
+#[derive(Clone, Copy)]
+pub struct Owners<'om> {
+	users: &'om HashMap<u32, Owner>,
+	groups: &'om HashMap<u32, Owner>,
+}
+
+impl Owners<'_> {
+	/// Get the resolved user [`Owner`] for the given UID, if it was resolved.
+	pub fn user(&self, uid: u32) -> Option<&Owner> {
+		self.users.get(&uid)
+	}
+
+	/// Get the resolved group [`Owner`] for the given GID, if it was resolved.
+	pub fn group(&self, gid: u32) -> Option<&Owner> {
+		self.groups.get(&gid)
+	}
 }
 
 /// Represents the owner of a node, be it a user or a group.

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -40,63 +40,63 @@ impl Default for OwnerMan {
 }
 
 impl OwnerMan {
-	fn lookup_user(&mut self, uid: u32) -> Owner {
-		Owner {
-			entity: Entity::User,
-			id: uid,
-			name: self
-				.cache
-				.get_user_by_uid(uid)
-				.map(|user| user.name().to_string_lossy().into()),
-			is_curr: uid == self.curr_uid,
-		}
-	}
-
-	fn lookup_group(&mut self, gid: u32) -> Owner {
-		if let Some(group) = self.cache.get_group_by_gid(gid) {
-			Owner {
-				entity: Entity::Group,
-				id: gid,
-				name: Some(group.name().to_string_lossy().into()),
-				is_curr: self.curr_user.as_ref().is_some_and(|user| {
-					group
-						.members()
-						.iter()
-						.any(|username| username == user.name())
-				}),
-			}
-		} else {
-			Owner {
-				entity: Entity::Group,
-				id: gid,
-				name: None,
-				is_curr: false,
-			}
-		}
-	}
-
 	/// Get the [`Owner`] instance of the user corresponding to the given UID.
 	///
 	/// The result is cached and returned by reference, so the common rendering
-	/// path does not clone the owner (and its name) once per node.
+	/// path does not clone the owner (and its name) once per node. Destructuring
+	/// `self` lets the `or_insert_with` closure borrow only the cache and current
+	/// UID, leaving `users` free for the `entry` call (a single hash lookup).
 	pub fn user(&mut self, uid: u32) -> &Owner {
-		if !self.users.contains_key(&uid) {
-			let user = self.lookup_user(uid);
-			self.users.insert(uid, user);
-		}
-		&self.users[&uid]
+		let Self {
+			cache,
+			curr_uid,
+			users,
+			..
+		} = self;
+		users.entry(uid).or_insert_with(|| Owner {
+			entity: Entity::User,
+			id: uid,
+			name: cache
+				.get_user_by_uid(uid)
+				.map(|user| user.name().to_string_lossy().into()),
+			is_curr: uid == *curr_uid,
+		})
 	}
 
 	/// Get the [`Owner`] instance of the group corresponding to the given GID.
 	///
 	/// The result is cached and returned by reference, so the common rendering
-	/// path does not clone the owner (and its name) once per node.
+	/// path does not clone the owner (and its name) once per node. As in
+	/// [`Self::user`], destructuring keeps the `entry` borrow disjoint from the
+	/// cache and current-user borrows the closure needs.
 	pub fn group(&mut self, gid: u32) -> &Owner {
-		if !self.groups.contains_key(&gid) {
-			let group = self.lookup_group(gid);
-			self.groups.insert(gid, group);
-		}
-		&self.groups[&gid]
+		let Self {
+			cache,
+			curr_user,
+			groups,
+			..
+		} = self;
+		groups
+			.entry(gid)
+			.or_insert_with(|| match cache.get_group_by_gid(gid) {
+				Some(group) => Owner {
+					entity: Entity::Group,
+					id: gid,
+					name: Some(group.name().to_string_lossy().into()),
+					is_curr: curr_user.as_ref().is_some_and(|user| {
+						group
+							.members()
+							.iter()
+							.any(|username| username == user.name())
+					}),
+				},
+				None => Owner {
+					entity: Entity::Group,
+					id: gid,
+					name: None,
+					is_curr: false,
+				},
+			})
 	}
 
 	/// Get an immutable, shareable view over the already-resolved owners.
@@ -146,7 +146,7 @@ pub struct Owner {
 }
 
 impl Owner {
-	fn format(&self, text: &String, constants: &EntryConst) -> String {
+	fn format(&self, text: &str, constants: &EntryConst) -> String {
 		let directives = match (&self.entity, self.is_curr) {
 			(Entity::User, true) => &constants.user_styles.curr,
 			(Entity::User, false) => &constants.user_styles.other,

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -76,21 +76,27 @@ impl OwnerMan {
 	}
 
 	/// Get the [`Owner`] instance of the user corresponding to the given UID.
-	pub fn user(&mut self, uid: u32) -> Owner {
-		self.users.get(&uid).cloned().unwrap_or_else(|| {
+	///
+	/// The result is cached and returned by reference, so the common rendering
+	/// path does not clone the owner (and its name) once per node.
+	pub fn user(&mut self, uid: u32) -> &Owner {
+		if !self.users.contains_key(&uid) {
 			let user = self.lookup_user(uid);
-			self.users.insert(uid, user.clone());
-			user
-		})
+			self.users.insert(uid, user);
+		}
+		&self.users[&uid]
 	}
 
 	/// Get the [`Owner`] instance of the group corresponding to the given GID.
-	pub fn group(&mut self, gid: u32) -> Owner {
-		self.groups.get(&gid).cloned().unwrap_or_else(|| {
+	///
+	/// The result is cached and returned by reference, so the common rendering
+	/// path does not clone the owner (and its name) once per node.
+	pub fn group(&mut self, gid: u32) -> &Owner {
+		if !self.groups.contains_key(&gid) {
 			let group = self.lookup_group(gid);
-			self.groups.insert(gid, group.clone());
-			group
-		})
+			self.groups.insert(gid, group);
+		}
+		&self.groups[&gid]
 	}
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,7 +1,9 @@
 mod cell;
 mod grid;
+mod rendered;
 mod table;
 
 pub use cell::Cell;
 pub use grid::Grid;
+pub use rendered::{render_rows, Rendered};
 pub use table::Table;

--- a/src/output/cell.rs
+++ b/src/output/cell.rs
@@ -41,7 +41,7 @@ impl Cell {
 	/// * `text` - the text to print in the cell
 	/// * `width` - the width that the cell should span
 	/// * `directives` - styles to apply to the entire cell, including padding
-	pub fn print<S>(&self, text: S, width: &Option<usize>, directives: Option<String>) -> String
+	pub fn print<S>(&self, text: S, width: &Option<usize>, directives: Option<&str>) -> String
 	where
 		S: AsRef<str>,
 	{
@@ -68,7 +68,7 @@ impl Cell {
 
 		if let Some(directives) = directives {
 			content.insert_str(0, "<>");
-			content.insert_str(1, &directives);
+			content.insert_str(1, directives);
 			content.push_str("</>");
 		}
 

--- a/src/output/cell.rs
+++ b/src/output/cell.rs
@@ -1,5 +1,6 @@
 use crate::fmt::{len, render};
 use crate::gfx::strip_image;
+use crate::output::Rendered;
 use std::fmt::Alignment;
 
 /// Represents one cell in the rendered output.
@@ -30,24 +31,10 @@ impl Cell {
 		Self { alignment, padding }
 	}
 
-	/// Return the content of the cell, padded to the given width and aligned
-	/// as per the cell's alignment directive.
-	///
-	/// This function calls render to ensure that markup in the cell contents
-	/// is rendered into ANSI escape sequences.
-	///
-	/// # Arguments
-	///
-	/// * `text` - the text to print in the cell
-	/// * `width` - the width that the cell should span
-	/// * `directives` - styles to apply to the entire cell, including padding
-	pub fn print<S>(&self, text: S, width: &Option<usize>, directives: Option<&str>) -> String
-	where
-		S: AsRef<str>,
-	{
-		let text = text.as_ref();
-		let text_len = len(strip_image(text)); // This `len` can understand markup.
-
+	/// Compute the left and right padding strings needed to span a cell of the
+	/// given rendered `text_len` to `width`, honouring the cell's alignment and
+	/// fixed padding.
+	fn padding(&self, text_len: usize, width: &Option<usize>) -> (String, String) {
 		let (left, right): (usize, usize) = match width {
 			Some(width) if *width > text_len => {
 				let pad = width - text_len;
@@ -59,10 +46,52 @@ impl Cell {
 			}
 			_ => (0, 0),
 		};
-		let (left, right) = (
+		(
 			" ".repeat(left + self.padding.0),
 			" ".repeat(right + self.padding.1),
-		);
+		)
+	}
+
+	/// Return a pre-rendered cell, padded to the given width and aligned as per
+	/// the cell's alignment directive.
+	///
+	/// The cell's markup has already been converted to ANSI escape codes and its
+	/// width measured (see [`Rendered`]), so this hot path performs no markup
+	/// parsing — it only prepends and appends padding spaces.
+	///
+	/// # Arguments
+	///
+	/// * `cell` - the pre-rendered cell content and its display width
+	/// * `width` - the width that the cell should span
+	pub fn print(&self, cell: &Rendered, width: &Option<usize>) -> String {
+		let (left, right) = self.padding(cell.width, width);
+		format!("{left}{}{right}", cell.text)
+	}
+
+	/// Return a cell rendered from markup, padded to the given width and aligned
+	/// as per the cell's alignment directive.
+	///
+	/// Unlike [`print`](Self::print) this still parses markup, so it is reserved
+	/// for the rare cells (such as table headers) that are produced as markup
+	/// at print time rather than pre-rendered per row.
+	///
+	/// # Arguments
+	///
+	/// * `text` - the marked-up text to render into the cell
+	/// * `width` - the width that the cell should span
+	/// * `directives` - styles to apply to the entire cell, including padding
+	pub fn print_markup<S>(
+		&self,
+		text: S,
+		width: &Option<usize>,
+		directives: Option<&str>,
+	) -> String
+	where
+		S: AsRef<str>,
+	{
+		let text = text.as_ref();
+		let text_len = len(strip_image(text)); // This `len` can understand markup.
+		let (left, right) = self.padding(text_len, width);
 
 		let mut content = format!("{left}{text}{right}");
 
@@ -88,7 +117,7 @@ mod tests {
 				#[test]
 				fn $name() {
 					let cell = Cell { padding: ($left, $right), ..Cell::default() };
-					assert_eq!(cell.print($text, &None, None), $expected);
+					assert_eq!(cell.print_markup($text, &None, None), $expected);
 				}
 			)*
 		};
@@ -107,7 +136,7 @@ mod tests {
 				fn $name() {
 					colored::control::set_override(true); // needed when running tests in CLion
 					let cell = Cell{ alignment: $alignment, ..Cell::default() };
-					assert_eq!(cell.print($text, &$width, None), $expected);
+					assert_eq!(cell.print_markup($text, &$width, None), $expected);
 				}
 			)*
 		};

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -1,8 +1,6 @@
 use crate::config::AppConst;
 use crate::enums::DetailField;
-use crate::fmt::len;
-use crate::gfx::strip_image;
-use crate::output::Cell;
+use crate::output::{Cell, Rendered};
 use crate::PLS;
 use std::fmt::Alignment;
 use std::io::{BufWriter, Write};
@@ -17,11 +15,12 @@ use std::io::{BufWriter, Write};
 /// the number of lines has been minimised, it minimises the column count by
 /// making each column take the maximum number of rows.
 pub struct Grid {
-	pub entries: Vec<String>,
+	pub entries: Vec<Rendered>,
 }
 
 impl Grid {
-	/// Create a new instance of `Grid`, taking ownership of the given entries.
+	/// Create a new instance of `Grid`, rendering and measuring the name column
+	/// of the given entries up front.
 	pub fn new(entries: Vec<Vec<String>>) -> Self {
 		// The grid renders only the name column; find its position in the
 		// configured detail fields and pull that value out of each row.
@@ -37,13 +36,14 @@ impl Grid {
 					Some(idx) if idx < entry.len() => entry.swap_remove(idx),
 					_ => String::default(),
 				})
+				.map(|markup| Rendered::new(&markup))
 				.collect(),
 		}
 	}
 
 	/// Render the grid to STDOUT.
 	pub fn render(&self, _app_const: &AppConst) {
-		let mut max_width = self.entries.iter().map(|e| strip_image(e)).map(len).max();
+		let mut max_width = self.entries.iter().map(|e| e.width).max();
 		let max_cols = self.columns(max_width);
 
 		let entry_len = self.entries.len();
@@ -63,7 +63,8 @@ impl Grid {
 		if cols > 1 && PLS.args.down {
 			self.print(&self.down(rows), cols, max_width);
 		} else {
-			self.print(&self.entries, cols, max_width);
+			let entries: Vec<&Rendered> = self.entries.iter().collect();
+			self.print(&entries, cols, max_width);
 		};
 	}
 
@@ -71,10 +72,7 @@ impl Grid {
 	///
 	/// This prints the entries in the specified number of columns, each cell
 	/// padded to span the given max-width.
-	fn print<S>(&self, entries: &[S], cols: usize, max_width: Option<usize>)
-	where
-		S: AsRef<str>,
-	{
+	fn print(&self, entries: &[&Rendered], cols: usize, max_width: Option<usize>) {
 		let entry_len = self.entries.len();
 
 		let cell = Cell::new(Alignment::Left, (0, 2));
@@ -83,13 +81,14 @@ impl Grid {
 		// Buffer the whole grid behind a single stdout lock so that each cell
 		// does not incur its own lock acquisition and write syscall.
 		let mut out = BufWriter::new(std::io::stdout().lock());
-		for (idx, text) in entries.iter().enumerate() {
+		for (idx, cell_content) in entries.iter().enumerate() {
 			if idx % cols == cols - 1 || idx == entry_len - 1 {
-				let _ = writeln!(out, "{}", end_cell.print(text, &max_width, None));
+				let _ = writeln!(out, "{}", end_cell.print(cell_content, &max_width));
 			} else {
-				let _ = write!(out, "{}", cell.print(text, &max_width, None));
+				let _ = write!(out, "{}", cell.print(cell_content, &max_width));
 			}
 		}
+		let _ = out.flush();
 	}
 
 	/// Shuffle the entries to enable printing down instead of across.
@@ -97,7 +96,7 @@ impl Grid {
 	/// Since terminals can only print row-by-row, we split the entries into
 	/// columns and then pick one cell per column, going in cycles till all
 	/// cells are exhausted.
-	fn down(&self, rows: usize) -> Vec<&String> {
+	fn down(&self, rows: usize) -> Vec<&Rendered> {
 		let chunks: Vec<_> = self.entries.chunks(rows).collect();
 		(0..rows)
 			.flat_map(|row_idx| chunks.iter().filter_map(move |chunk| chunk.get(row_idx)))

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -43,7 +43,7 @@ impl Grid {
 
 	/// Render the grid to STDOUT.
 	pub fn render(&self, _app_const: &AppConst) {
-		let mut max_width = self.entries.iter().map(strip_image).map(len).max();
+		let mut max_width = self.entries.iter().map(|e| strip_image(e)).map(len).max();
 		let max_cols = self.columns(max_width);
 
 		let entry_len = self.entries.len();

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -2,6 +2,7 @@ use crate::config::AppConst;
 use crate::enums::DetailField;
 use crate::output::{Cell, Rendered};
 use crate::PLS;
+use rayon::prelude::*;
 use std::fmt::Alignment;
 use std::io::{BufWriter, Write};
 
@@ -31,7 +32,7 @@ impl Grid {
 			.position(|det| *det == DetailField::Name);
 		Self {
 			entries: entries
-				.into_iter()
+				.into_par_iter()
 				.map(|mut entry| match name_idx {
 					Some(idx) if idx < entry.len() => entry.swap_remove(idx),
 					_ => String::default(),

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -4,7 +4,7 @@ use crate::output::{Cell, Rendered};
 use crate::PLS;
 use rayon::prelude::*;
 use std::fmt::Alignment;
-use std::io::{BufWriter, Write};
+use std::io::{self, BufWriter, Write};
 
 /// The grid view renders the node names in a two dimensional layout to minimise
 /// scrolling. It does not support rendering of node metadata.
@@ -80,16 +80,20 @@ impl Grid {
 		let end_cell = Cell::new(Alignment::Left, (0, 0));
 
 		// Buffer the whole grid behind a single stdout lock so that each cell
-		// does not incur its own lock acquisition and write syscall.
+		// does not incur its own lock acquisition and write syscall. Writing
+		// stops at the first error (e.g. a closed pipe) instead of formatting
+		// the remaining cells for output that nobody will read.
 		let mut out = BufWriter::new(std::io::stdout().lock());
-		for (idx, cell_content) in entries.iter().enumerate() {
-			if idx % cols == cols - 1 || idx == entry_len - 1 {
-				let _ = writeln!(out, "{}", end_cell.print(cell_content, &max_width));
-			} else {
-				let _ = write!(out, "{}", cell.print(cell_content, &max_width));
+		let _: io::Result<()> = (|| {
+			for (idx, cell_content) in entries.iter().enumerate() {
+				if idx % cols == cols - 1 || idx == entry_len - 1 {
+					writeln!(out, "{}", end_cell.print(cell_content, &max_width))?;
+				} else {
+					write!(out, "{}", cell.print(cell_content, &max_width))?;
+				}
 			}
-		}
-		let _ = out.flush();
+			out.flush()
+		})();
 	}
 
 	/// Shuffle the entries to enable printing down instead of across.

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -4,7 +4,6 @@ use crate::fmt::len;
 use crate::gfx::strip_image;
 use crate::output::Cell;
 use crate::PLS;
-use std::collections::HashMap;
 use std::fmt::Alignment;
 use std::io::{BufWriter, Write};
 
@@ -23,11 +22,21 @@ pub struct Grid {
 
 impl Grid {
 	/// Create a new instance of `Grid`, taking ownership of the given entries.
-	pub fn new(entries: Vec<HashMap<DetailField, String>>) -> Self {
+	pub fn new(entries: Vec<Vec<String>>) -> Self {
+		// The grid renders only the name column; find its position in the
+		// configured detail fields and pull that value out of each row.
+		let name_idx = PLS
+			.args
+			.details
+			.iter()
+			.position(|det| *det == DetailField::Name);
 		Self {
 			entries: entries
 				.into_iter()
-				.map(|mut entry| entry.remove(&DetailField::Name).unwrap_or_default())
+				.map(|mut entry| match name_idx {
+					Some(idx) if idx < entry.len() => entry.swap_remove(idx),
+					_ => String::default(),
+				})
 				.collect(),
 		}
 	}

--- a/src/output/grid.rs
+++ b/src/output/grid.rs
@@ -6,6 +6,7 @@ use crate::output::Cell;
 use crate::PLS;
 use std::collections::HashMap;
 use std::fmt::Alignment;
+use std::io::{BufWriter, Write};
 
 /// The grid view renders the node names in a two dimensional layout to minimise
 /// scrolling. It does not support rendering of node metadata.
@@ -69,11 +70,15 @@ impl Grid {
 
 		let cell = Cell::new(Alignment::Left, (0, 2));
 		let end_cell = Cell::new(Alignment::Left, (0, 0));
+
+		// Buffer the whole grid behind a single stdout lock so that each cell
+		// does not incur its own lock acquisition and write syscall.
+		let mut out = BufWriter::new(std::io::stdout().lock());
 		for (idx, text) in entries.iter().enumerate() {
 			if idx % cols == cols - 1 || idx == entry_len - 1 {
-				println!("{}", &end_cell.print(text, &max_width, None));
+				let _ = writeln!(out, "{}", end_cell.print(text, &max_width, None));
 			} else {
-				print!("{}", &cell.print(text, &max_width, None));
+				let _ = write!(out, "{}", cell.print(text, &max_width, None));
 			}
 		}
 	}

--- a/src/output/rendered.rs
+++ b/src/output/rendered.rs
@@ -1,4 +1,5 @@
 use crate::fmt::render_and_measure;
+use rayon::prelude::*;
 
 /// A cell whose markup has already been converted to ANSI escape codes, paired
 /// with its rendered display width.
@@ -26,9 +27,11 @@ impl Rendered {
 /// Render and measure every cell of every row.
 ///
 /// This is the single point at which a group's markup rows are converted into
-/// printable, pre-measured cells.
+/// printable, pre-measured cells. Rendering a cell is pure, independent string
+/// work, so the rows are rendered in parallel across the global thread pool;
+/// `collect` preserves the original row order.
 pub fn render_rows(rows: Vec<Vec<String>>) -> Vec<Vec<Rendered>> {
-	rows.into_iter()
+	rows.into_par_iter()
 		.map(|row| row.into_iter().map(|cell| Rendered::new(&cell)).collect())
 		.collect()
 }

--- a/src/output/rendered.rs
+++ b/src/output/rendered.rs
@@ -1,0 +1,34 @@
+use crate::fmt::render_and_measure;
+
+/// A cell whose markup has already been converted to ANSI escape codes, paired
+/// with its rendered display width.
+///
+/// Rendering markup (parsing tags, applying styles) and measuring its width
+/// both require a pass over the string. Doing that work once up front — instead
+/// of repeatedly while computing column widths and again while printing — keeps
+/// the hot output path free of markup parsing.
+pub struct Rendered {
+	/// the cell content, already rendered from markup into ANSI escape codes
+	pub text: String,
+	/// the display width of [`text`](Self::text) in terminal columns, excluding
+	/// ANSI escape codes and terminal-graphics sequences
+	pub width: usize,
+}
+
+impl Rendered {
+	/// Render and measure the given markup string into a `Rendered` cell.
+	pub fn new(markup: &str) -> Self {
+		let (text, width) = render_and_measure(markup);
+		Self { text, width }
+	}
+}
+
+/// Render and measure every cell of every row.
+///
+/// This is the single point at which a group's markup rows are converted into
+/// printable, pre-measured cells.
+pub fn render_rows(rows: Vec<Vec<String>>) -> Vec<Vec<Rendered>> {
+	rows.into_iter()
+		.map(|row| row.into_iter().map(|cell| Rendered::new(&cell)).collect())
+		.collect()
+}

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -43,7 +43,7 @@ impl Table {
 		if PLS.args.header {
 			for (width, det, cell) in &iter_basis {
 				let name = det.name(app_const);
-				let directives = app_const.table.header_style.clone();
+				let directives = app_const.table.header_style.as_str();
 				print!("{}", &cell.print(name, width, Some(directives)));
 			}
 			println!();

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -2,7 +2,7 @@ use crate::config::AppConst;
 use crate::fmt::len;
 use crate::output::{render_rows, Rendered};
 use crate::PLS;
-use std::io::{BufWriter, Write};
+use std::io::{self, BufWriter, Write};
 use std::iter::once;
 
 /// The detailed renders node names, and optionally, chosen node metadata in
@@ -45,28 +45,32 @@ impl Table {
 			.collect();
 
 		// Buffer the whole table behind a single stdout lock so that each cell
-		// does not incur its own lock acquisition and write syscall.
+		// does not incur its own lock acquisition and write syscall. Writing
+		// stops at the first error (e.g. a closed pipe) instead of doing the
+		// remaining formatting work for output that nobody will read.
 		let mut out = BufWriter::new(std::io::stdout().lock());
-
-		if PLS.args.header {
-			let header_style = app_const.table.header_style.as_str();
-			for (width, det, cell) in &iter_basis {
-				let name = det.name(app_const);
-				let _ = write!(
-					out,
-					"{}",
-					cell.print_markup(name, width, Some(header_style))
-				);
+		let _: io::Result<()> = (|| {
+			if PLS.args.header {
+				let header_style = app_const.table.header_style.as_str();
+				for (width, det, cell) in &iter_basis {
+					let name = det.name(app_const);
+					write!(
+						out,
+						"{}",
+						cell.print_markup(name, width, Some(header_style))
+					)?;
+				}
+				writeln!(out)?;
 			}
-			let _ = writeln!(out);
-		}
 
-		for entry in &self.entries {
-			for ((width, _det, cell), value) in iter_basis.iter().zip(entry) {
-				let _ = write!(out, "{}", cell.print(value, width));
+			for entry in &self.entries {
+				for ((width, _det, cell), value) in iter_basis.iter().zip(entry) {
+					write!(out, "{}", cell.print(value, width))?;
+				}
+				writeln!(out)?;
 			}
-			let _ = writeln!(out);
-		}
+			Ok(())
+		})();
 	}
 
 	/// Get mapping of detail field to the maximum width of the cells in that

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -3,6 +3,7 @@ use crate::enums::DetailField;
 use crate::fmt::len;
 use crate::PLS;
 use std::collections::HashMap;
+use std::io::{BufWriter, Write};
 use std::iter::once;
 
 /// The detailed renders node names, and optionally, chosen node metadata in
@@ -40,20 +41,24 @@ impl Table {
 			})
 			.collect();
 
+		// Buffer the whole table behind a single stdout lock so that each cell
+		// does not incur its own lock acquisition and write syscall.
+		let mut out = BufWriter::new(std::io::stdout().lock());
+
 		if PLS.args.header {
+			let header_style = app_const.table.header_style.as_str();
 			for (width, det, cell) in &iter_basis {
 				let name = det.name(app_const);
-				let directives = app_const.table.header_style.as_str();
-				print!("{}", &cell.print(name, width, Some(directives)));
+				let _ = write!(out, "{}", cell.print(name, width, Some(header_style)));
 			}
-			println!();
+			let _ = writeln!(out);
 		}
 
 		for entry in &self.entries {
 			for (width, det, cell) in &iter_basis {
-				print!("{}", &cell.print(entry.get(det).unwrap(), width, None));
+				let _ = write!(out, "{}", cell.print(entry.get(det).unwrap(), width, None));
 			}
-			println!();
+			let _ = writeln!(out);
 		}
 	}
 

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -1,5 +1,6 @@
 use crate::config::AppConst;
 use crate::fmt::len;
+use crate::output::{render_rows, Rendered};
 use crate::PLS;
 use std::io::{BufWriter, Write};
 use std::iter::once;
@@ -11,14 +12,18 @@ use std::iter::once;
 /// the [grid view](crate::output::Grid).
 #[derive(Default)]
 pub struct Table {
-	pub entries: Vec<Vec<String>>,
+	pub entries: Vec<Vec<Rendered>>,
 	pub is_solo: bool,
 }
 
 impl Table {
-	/// Create a new instance of `Table`, taking ownership of the given entries.
+	/// Create a new instance of `Table`, rendering and measuring the given
+	/// markup entries up front so the layout never re-parses markup.
 	pub fn new(entries: Vec<Vec<String>>, is_solo: bool) -> Self {
-		Self { entries, is_solo }
+		Self {
+			entries: render_rows(entries),
+			is_solo,
+		}
 	}
 
 	/// Render the table to STDOUT.
@@ -47,14 +52,18 @@ impl Table {
 			let header_style = app_const.table.header_style.as_str();
 			for (width, det, cell) in &iter_basis {
 				let name = det.name(app_const);
-				let _ = write!(out, "{}", cell.print(name, width, Some(header_style)));
+				let _ = write!(
+					out,
+					"{}",
+					cell.print_markup(name, width, Some(header_style))
+				);
 			}
 			let _ = writeln!(out);
 		}
 
 		for entry in &self.entries {
 			for ((width, _det, cell), value) in iter_basis.iter().zip(entry) {
-				let _ = write!(out, "{}", cell.print(value, width, None));
+				let _ = write!(out, "{}", cell.print(value, width));
 			}
 			let _ = writeln!(out);
 		}
@@ -84,7 +93,7 @@ impl Table {
 				};
 				self.entries[0..end_lim]
 					.iter()
-					.filter_map(|entry| entry.get(det_idx).map(len))
+					.filter_map(|entry| entry.get(det_idx).map(|cell| cell.width))
 					.chain(once(if PLS.args.header {
 						len(det.name(app_const))
 					} else {

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -1,8 +1,6 @@
 use crate::config::AppConst;
-use crate::enums::DetailField;
 use crate::fmt::len;
 use crate::PLS;
-use std::collections::HashMap;
 use std::io::{BufWriter, Write};
 use std::iter::once;
 
@@ -13,13 +11,13 @@ use std::iter::once;
 /// the [grid view](crate::output::Grid).
 #[derive(Default)]
 pub struct Table {
-	pub entries: Vec<HashMap<DetailField, String>>,
+	pub entries: Vec<Vec<String>>,
 	pub is_solo: bool,
 }
 
 impl Table {
 	/// Create a new instance of `Table`, taking ownership of the given entries.
-	pub fn new(entries: Vec<HashMap<DetailField, String>>, is_solo: bool) -> Self {
+	pub fn new(entries: Vec<Vec<String>>, is_solo: bool) -> Self {
 		Self { entries, is_solo }
 	}
 
@@ -55,8 +53,8 @@ impl Table {
 		}
 
 		for entry in &self.entries {
-			for (width, det, cell) in &iter_basis {
-				let _ = write!(out, "{}", cell.print(entry.get(det).unwrap(), width, None));
+			for ((width, _det, cell), value) in iter_basis.iter().zip(entry) {
+				let _ = write!(out, "{}", cell.print(value, width, None));
 			}
 			let _ = writeln!(out);
 		}
@@ -86,7 +84,7 @@ impl Table {
 				};
 				self.entries[0..end_lim]
 					.iter()
-					.filter_map(|entry| entry.get(det).map(len))
+					.filter_map(|entry| entry.get(det_idx).map(len))
 					.chain(once(if PLS.args.header {
 						len(det.name(app_const))
 					} else {

--- a/src/traits/detail.rs
+++ b/src/traits/detail.rs
@@ -6,8 +6,22 @@ use crate::PLS;
 use log::warn;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+use std::sync::LazyLock;
 use std::time::SystemTime;
 use time::{format_description, OffsetDateTime, UtcOffset};
+
+/// The current local UTC offset, resolved once for the lifetime of the process.
+///
+/// Determining the offset involves a syscall, so caching it avoids repeating
+/// that work for every timestamp of every node.
+static LOCAL_OFFSET: LazyLock<Option<UtcOffset>> =
+	LazyLock::new(|| match UtcOffset::current_local_offset() {
+		Ok(offset) => Some(offset),
+		Err(_) => {
+			warn!("Could not determine UTC offset");
+			None
+		}
+	});
 
 pub trait Detail {
 	fn size_val(&self) -> Option<u64>;
@@ -190,11 +204,8 @@ impl Detail for Node<'_> {
 	fn time(&self, field: DetailField, entry_const: &EntryConst) -> Option<String> {
 		self.time_val(field).map(|time| {
 			let mut dt: OffsetDateTime = time.into();
-			match UtcOffset::current_local_offset() {
-				Ok(offset) => dt = dt.to_offset(offset),
-				Err(_) => {
-					warn!("Could not determine UTC offset")
-				}
+			if let Some(offset) = *LOCAL_OFFSET {
+				dt = dt.to_offset(offset);
 			}
 			let format = format_description::parse_borrowed::<2>(
 				entry_const.timestamp_formats.get(&field).unwrap(),

--- a/src/traits/detail.rs
+++ b/src/traits/detail.rs
@@ -98,9 +98,8 @@ impl Detail for Node<'_> {
 	/// This function returns a marked-up string.
 	fn dev(&self, entry_const: &EntryConst) -> Option<String> {
 		self.meta_ok().map(|meta| {
-			let dev = meta.dev().to_string();
 			let directives = &entry_const.dev_style;
-			format!("<{directives}>{dev}</>")
+			format!("<{directives}>{}</>", meta.dev())
 		})
 	}
 
@@ -109,9 +108,8 @@ impl Detail for Node<'_> {
 	/// This function returns a marked-up string.
 	fn ino(&self, entry_const: &EntryConst) -> Option<String> {
 		self.meta_ok().map(|meta| {
-			let ino = meta.ino().to_string();
 			let directives = &entry_const.ino_style;
-			format!("<{directives}>{ino}</>")
+			format!("<{directives}>{}</>", meta.ino())
 		})
 	}
 

--- a/src/traits/detail.rs
+++ b/src/traits/detail.rs
@@ -80,13 +80,13 @@ impl Detail for Node<'_> {
 	/// Get the name of the user that owns this node, if known.
 	fn user_val(&self, owner_man: &mut OwnerMan) -> Option<String> {
 		self.meta_ok()
-			.and_then(|meta| owner_man.user(meta.uid()).name)
+			.and_then(|meta| owner_man.user(meta.uid()).name.clone())
 	}
 
 	/// Get the name of the group that owns this node, if known.
 	fn group_val(&self, owner_man: &mut OwnerMan) -> Option<String> {
 		self.meta_ok()
-			.and_then(|meta| owner_man.group(meta.gid()).name)
+			.and_then(|meta| owner_man.group(meta.gid()).name.clone())
 	}
 
 	// ===========

--- a/src/traits/detail.rs
+++ b/src/traits/detail.rs
@@ -1,7 +1,7 @@
 use crate::config::EntryConst;
 use crate::enums::{DetailField, Typ};
 use crate::ext::Ctime;
-use crate::models::{Node, OwnerMan, Perm};
+use crate::models::{Node, Owners, Perm};
 use crate::PLS;
 use log::warn;
 #[cfg(unix)]
@@ -27,18 +27,18 @@ pub trait Detail {
 	fn size_val(&self) -> Option<u64>;
 	fn blocks_val(&self) -> Option<u64>;
 	fn time_val(&self, field: DetailField) -> Option<SystemTime>;
-	fn user_val(&self, owner_man: &mut OwnerMan) -> Option<String>;
-	fn group_val(&self, owner_man: &mut OwnerMan) -> Option<String>;
+	fn user_val(&self, owners: Owners) -> Option<String>;
+	fn group_val(&self, owners: Owners) -> Option<String>;
 
 	fn dev(&self, entry_const: &EntryConst) -> Option<String>;
 	fn ino(&self, entry_const: &EntryConst) -> Option<String>;
 	fn nlink(&self, entry_const: &EntryConst) -> Option<String>;
 	fn perm(&self, entry_const: &EntryConst) -> Option<String>;
 	fn oct(&self, entry_const: &EntryConst) -> Option<String>;
-	fn user(&self, owner_man: &mut OwnerMan, entry_const: &EntryConst) -> Option<String>;
-	fn uid(&self, owner_man: &mut OwnerMan, entry_const: &EntryConst) -> Option<String>;
-	fn group(&self, owner_man: &mut OwnerMan, entry_const: &EntryConst) -> Option<String>;
-	fn gid(&self, owner_man: &mut OwnerMan, entry_const: &EntryConst) -> Option<String>;
+	fn user(&self, owners: Owners, entry_const: &EntryConst) -> Option<String>;
+	fn uid(&self, owners: Owners, entry_const: &EntryConst) -> Option<String>;
+	fn group(&self, owners: Owners, entry_const: &EntryConst) -> Option<String>;
+	fn gid(&self, owners: Owners, entry_const: &EntryConst) -> Option<String>;
 	fn size(&self, entry_const: &EntryConst) -> Option<String>;
 	fn blocks(&self, entry_const: &EntryConst) -> Option<String>;
 	fn time(&self, field: DetailField, entry_const: &EntryConst) -> Option<String>;
@@ -78,15 +78,17 @@ impl Detail for Node<'_> {
 	}
 
 	/// Get the name of the user that owns this node, if known.
-	fn user_val(&self, owner_man: &mut OwnerMan) -> Option<String> {
+	fn user_val(&self, owners: Owners) -> Option<String> {
 		self.meta_ok()
-			.and_then(|meta| owner_man.user(meta.uid()).name.clone())
+			.and_then(|meta| owners.user(meta.uid()))
+			.and_then(|owner| owner.name.clone())
 	}
 
 	/// Get the name of the group that owns this node, if known.
-	fn group_val(&self, owner_man: &mut OwnerMan) -> Option<String> {
+	fn group_val(&self, owners: Owners) -> Option<String> {
 		self.meta_ok()
-			.and_then(|meta| owner_man.group(meta.gid()).name.clone())
+			.and_then(|meta| owners.group(meta.gid()))
+			.and_then(|owner| owner.name.clone())
 	}
 
 	// ===========
@@ -145,36 +147,40 @@ impl Detail for Node<'_> {
 	/// the owner is the current user.
 	///
 	/// This function returns a marked-up string.
-	fn user(&self, owner_man: &mut OwnerMan, entry_const: &EntryConst) -> Option<String> {
+	fn user(&self, owners: Owners, entry_const: &EntryConst) -> Option<String> {
 		self.meta_ok()
-			.map(|meta| owner_man.user(meta.uid()).name(entry_const))
+			.and_then(|meta| owners.user(meta.uid()))
+			.map(|owner| owner.name(entry_const))
 	}
 
 	/// Get the UID of the user that owns this node. The UID is highlighted if
 	/// the owner is the current user.
 	///
 	/// This function returns a marked-up string.
-	fn uid(&self, owner_man: &mut OwnerMan, entry_const: &EntryConst) -> Option<String> {
+	fn uid(&self, owners: Owners, entry_const: &EntryConst) -> Option<String> {
 		self.meta_ok()
-			.map(|meta| owner_man.user(meta.uid()).id(entry_const))
+			.and_then(|meta| owners.user(meta.uid()))
+			.map(|owner| owner.id(entry_const))
 	}
 
 	/// Get the name of the group that owns this node. The name is highlighted
 	/// if the current user belongs to this group.
 	///
 	/// This function returns a marked-up string.
-	fn group(&self, owner_man: &mut OwnerMan, entry_const: &EntryConst) -> Option<String> {
+	fn group(&self, owners: Owners, entry_const: &EntryConst) -> Option<String> {
 		self.meta_ok()
-			.map(|meta| owner_man.group(meta.gid()).name(entry_const))
+			.and_then(|meta| owners.group(meta.gid()))
+			.map(|owner| owner.name(entry_const))
 	}
 
 	/// Get the GID of the group that owns this node. The GID is highlighted
 	/// if the current user belongs to this group.
 	///
 	/// This function returns a marked-up string.
-	fn gid(&self, owner_man: &mut OwnerMan, entry_const: &EntryConst) -> Option<String> {
+	fn gid(&self, owners: Owners, entry_const: &EntryConst) -> Option<String> {
 		self.meta_ok()
-			.map(|meta| owner_man.group(meta.gid()).id(entry_const))
+			.and_then(|meta| owners.group(meta.gid()))
+			.map(|owner| owner.id(entry_const))
 	}
 
 	/// Get the size of the file in bytes, optionally with higher units in

--- a/src/traits/detail.rs
+++ b/src/traits/detail.rs
@@ -8,7 +8,7 @@ use log::warn;
 use std::os::unix::fs::MetadataExt;
 use std::sync::LazyLock;
 use std::time::SystemTime;
-use time::{format_description, OffsetDateTime, UtcOffset};
+use time::{OffsetDateTime, UtcOffset};
 
 /// The current local UTC offset, resolved once for the lifetime of the process.
 ///
@@ -200,16 +200,13 @@ impl Detail for Node<'_> {
 	///
 	/// This function returns a marked-up string.
 	fn time(&self, field: DetailField, entry_const: &EntryConst) -> Option<String> {
-		self.time_val(field).map(|time| {
+		self.time_val(field).and_then(|time| {
 			let mut dt: OffsetDateTime = time.into();
 			if let Some(offset) = *LOCAL_OFFSET {
 				dt = dt.to_offset(offset);
 			}
-			let format = format_description::parse_borrowed::<2>(
-				entry_const.timestamp_formats.get(&field).unwrap(),
-			)
-			.unwrap();
-			dt.format(&format).unwrap()
+			let format = entry_const.timestamp_format(field)?;
+			dt.format(format).ok()
 		})
 	}
 }

--- a/src/traits/imp.rs
+++ b/src/traits/imp.rs
@@ -9,7 +9,7 @@ pub trait Imp {
 
 	fn is_visible(&self, conf: &Conf) -> bool;
 
-	fn directives(&self, app_const: &AppConst) -> Option<String>;
+	fn directives<'a>(&self, app_const: &'a AppConst) -> Option<&'a str>;
 }
 
 impl Imp for Node<'_> {
@@ -67,13 +67,13 @@ impl Imp for Node<'_> {
 	/// If the node's importance is above the maximum defined, it will be set to
 	/// the maximum. If it is below the minimum defined, it will already be
 	/// hidden by [`is_visible`](Imp::is_visible).
-	fn directives(&self, app_const: &AppConst) -> Option<String> {
+	fn directives<'a>(&self, app_const: &'a AppConst) -> Option<&'a str> {
 		let mut rel_imp = self.imp_val();
 		let max_val = app_const.max_imp();
 		let min_val = app_const.min_imp();
 		debug!("\"{self}\" has relative importance {rel_imp} (min: {min_val}, max: {max_val})");
 
 		rel_imp = rel_imp.clamp(min_val, max_val);
-		app_const.imp_map.get(&rel_imp).cloned()
+		app_const.imp_map.get(&rel_imp).map(String::as_str)
 	}
 }

--- a/src/traits/name.rs
+++ b/src/traits/name.rs
@@ -62,7 +62,7 @@ impl Name for Node<'_> {
 	/// If the node name starts with a dot, the dot is dimmed. If not, the name
 	/// is left-padded with a space to line up the alphabetic characters.
 	fn aligned_name(&self) -> String {
-		let path = PathBuf::from(&self.display_name);
+		let path = PathBuf::from(self.disp_name());
 		if let Some(name) = path.file_name() {
 			let name = name.to_string_lossy();
 
@@ -77,6 +77,6 @@ impl Name for Node<'_> {
 				return parent.join(aligned_name).to_string_lossy().to_string();
 			}
 		}
-		self.display_name.clone()
+		self.disp_name().to_string()
 	}
 }

--- a/src/traits/name.rs
+++ b/src/traits/name.rs
@@ -2,9 +2,9 @@ use crate::models::Node;
 use std::path::PathBuf;
 
 pub trait Name {
-	fn ext(&self) -> String;
+	fn ext(&self) -> &str;
 	fn stem(&self) -> String;
-	fn cname(&self) -> String;
+	fn cname(&self) -> &str;
 
 	fn aligned_name(&self) -> String;
 }
@@ -16,13 +16,16 @@ impl Name for Node<'_> {
 
 	/// Get the extension for a node.
 	///
-	/// Returns a blank string if the node does not have an extension.
-	fn ext(&self) -> String {
-		self.path
-			.extension()
-			.unwrap_or_default()
-			.to_string_lossy()
-			.to_string()
+	/// Returns a blank string if the node does not have an extension. The value
+	/// is computed once and cached, as it is used for sorting.
+	fn ext(&self) -> &str {
+		self.ext_cache.get_or_init(|| {
+			self.path
+				.extension()
+				.unwrap_or_default()
+				.to_string_lossy()
+				.to_string()
+		})
 	}
 
 	/// Get the name for the node, without the extension, if any.
@@ -39,12 +42,15 @@ impl Name for Node<'_> {
 	/// Get the canonical name for the node.
 	///
 	/// The canonical name is the name of the node, stripped of leading symbols
-	/// and normalised to lowercase.
-	fn cname(&self) -> String {
-		self.name
-			.to_lowercase()
-			.trim_start_matches(|c: char| !c.is_alphanumeric())
-			.to_string()
+	/// and normalised to lowercase. The value is computed once and cached, as it
+	/// is used for sorting.
+	fn cname(&self) -> &str {
+		self.cname_cache.get_or_init(|| {
+			self.name
+				.to_lowercase()
+				.trim_start_matches(|c: char| !c.is_alphanumeric())
+				.to_string()
+		})
 	}
 
 	// ===============

--- a/src/utils/vectors.rs
+++ b/src/utils/vectors.rs
@@ -4,22 +4,24 @@
 //!
 //! * [`dedup`]
 
-use std::collections::{HashSet, VecDeque};
+use indexmap::IndexSet;
+use std::hash::Hash;
 
 /// Deduplicate a vector, by preserving the last appearance of a value.
+///
+/// The values are moved into an [`IndexSet`], which both deduplicates and
+/// remembers insertion order, so it doubles as the output buffer and the
+/// "seen" set. Inserting in reverse means the first insertion of each value is
+/// its last appearance in the input; reversing again restores the original
+/// order. This needs no `Clone` bound and never copies a value.
 ///
 /// # Arguments
 ///
 /// * `vec` - the vector to deduplicate
-pub fn dedup<T: std::hash::Hash + Eq + Clone>(vec: Vec<T>) -> Vec<T> {
-	let mut dedup = VecDeque::new();
-
-	let mut set = HashSet::new();
+pub fn dedup<T: Hash + Eq>(vec: Vec<T>) -> Vec<T> {
+	let mut set: IndexSet<T> = IndexSet::with_capacity(vec.len());
 	for item in vec.into_iter().rev() {
-		if set.insert(item.clone()) {
-			dedup.push_front(item);
-		}
+		set.insert(item);
 	}
-
-	dedup.into()
+	set.into_iter().rev().collect()
 }


### PR DESCRIPTION
> [!IMPORTANT]
>
> The diff in this PR is AI generated. It's been implemented as a separate PR because I want to make sure it doesn't break anything and I also don't want to merge code before I fully understand what it does and how it works.

This PR implements a lot of different approaches to improve performance. From a rudimentary local benchmark, the improvements range from 2x to 4x faster in some cases.

## Benchmark

Listing a directory of **10,000 files** is **3.8×–6.4× faster**, with the
biggest wins on detailed (`-d`) views:

| Scenario | `0.0.1-beta.11` | `perf_improv` | Speedup |
| --- | ---: | ---: | ---: |
| Default (names only) | 91.0 ± 2.5 ms | 24.1 ± 0.8 ms | **3.78×** |
| Grid (`-g true`) | 94.3 ± 1.7 ms | 25.0 ± 0.9 ms | **3.77×** |
| Detailed (`-d std`) | 286.5 ± 5.5 ms | 53.8 ± 1.6 ms | **5.32×** |
| Detailed (`-d all`) | 468.3 ± 5.9 ms | 73.3 ± 3.8 ms | **6.39×** |
| Owner columns¹ | 239.5 ± 4.3 ms | 49.4 ± 2.4 ms | **4.85×** |
| Nested tree, `-d all`² | 10.6 ± 0.5 ms | 9.2 ± 0.5 ms | 1.15× |

¹ `-d user -d group -d uid -d gid -d perm`  
² 100-entry directory — included to show small listings are not regressed.

## Output (unchanged)

The optimized binary produces **byte-identical output** to `0.0.1-beta.11` across every view tested (default, grid, `-d std`, `-d all`, owner columns) on both the flat and nested fixtures, after masking timestamp values that legitimately drift between runs. The full test suite (142 tests) passes.

## How

`-d all` is illustrative (mean wall vs. total CPU time):

| | wall | user CPU | sys |
| --- | ---: | ---: | ---: |
| `0.0.1-beta.11` | 468 ms | 428 ms | 38 ms |
| `perf_improv` | 73 ms | 285 ms | 148 ms |

Two effects stack:

1. **Less work per listing.** Total CPU drops (428 → 285 ms user) because markup is parsed and measured once per cell instead of ~3×, ANSI style affixes are memoized instead of rebuilt per run, timestamp formats are parsed once, and a long tail of per-node clones/allocations were removed.
2. **Work spread across cores.** What remains is rendered in parallel (`user` > `wall`), so the 285 ms of CPU lands in 73 ms of wall time on this 14-core machine.

The headline optimizations on the branch:

- Read node type from `d_type` and fetch metadata lazily (name-only views skip `stat` entirely; detailed views `stat` once instead of twice)
- Pre-render and measure each cell once into a `Rendered` value, with memoized ANSI affixes — eliminates repeated markup parsing on the output path
- Render node rows in parallel with `rayon`
- Parse each timestamp format once and cache it on `EntryConst`
- Positional rows, cached sort keys, zero-copy markup parsing, owners resolved by reference through a shareable view, and assorted clone/allocation removals